### PR TITLE
音量調整機能を追加する

### DIFF
--- a/domain/operations.py
+++ b/domain/operations.py
@@ -1,4 +1,5 @@
 TRIM = "trim"
 CONCAT = "concat"
 RESIZE = "resize"
+VOLUME = "volume"
 EXIT = "exit"

--- a/ffmpeg/commands.py
+++ b/ffmpeg/commands.py
@@ -47,6 +47,24 @@ def build_resize_command(
     ]
 
 
+def build_volume_command(
+    input_file: str,
+    output_file: str,
+    volume_level: float,
+) -> list[str]:
+    return [
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_file,
+        "-filter:a",
+        f"volume={volume_level}",
+        "-c:v",
+        "copy",
+        output_file,
+    ]
+
+
 def create_concat_list_file(input_files: list[str]) -> str:
     temp = NamedTemporaryFile(
         mode="w",

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from ui.main_menu import prompt_main_menu
 from usecases.concat_flow import run_concat_flow
 from usecases.resize_flow import run_resize_flow
 from usecases.trim_flow import run_trim_flow
+from usecases.volume_flow import run_volume_flow
 
 OperationHandler = Callable[[], None]
 
@@ -24,6 +25,7 @@ def build_operation_handlers() -> dict[str, OperationHandler]:
         operations.TRIM: run_trim_flow,
         operations.CONCAT: run_concat_flow,
         operations.RESIZE: run_resize_flow,
+        operations.VOLUME: run_volume_flow,
         operations.EXIT: exit_program,
     }
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,6 +6,7 @@ from ffmpeg.commands import (
     build_concat_reencode_command,
     build_resize_command,
     build_trim_command,
+    build_volume_command,
 )
 
 
@@ -99,6 +100,34 @@ class TestBuildConcatReencodeCommand(unittest.TestCase):
                 "out.mp4",
             ],
         )
+
+
+class TestBuildVolumeCommand(unittest.TestCase):
+    def test_basic(self):
+        command = build_volume_command("in.mp4", "out.mp4", 1.5)
+        self.assertEqual(
+            command,
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                "in.mp4",
+                "-filter:a",
+                "volume=1.5",
+                "-c:v",
+                "copy",
+                "out.mp4",
+            ],
+        )
+
+    def test_volume_one_keeps_original(self):
+        command = build_volume_command("in.mp4", "out.mp4", 1.0)
+        self.assertIn("volume=1.0", command)
+
+    def test_video_stream_is_copied(self):
+        command = build_volume_command("in.mp4", "out.mp4", 2.0)
+        copy_idx = command.index("copy")
+        self.assertEqual(command[copy_idx - 1], "-c:v")
 
 
 if __name__ == "__main__":

--- a/tests/test_value_validators.py
+++ b/tests/test_value_validators.py
@@ -1,7 +1,7 @@
 import unittest
 
 from shared.errors import ValidationError
-from validation.value_validators import parse_time_input, validate_dimension
+from validation.value_validators import parse_time_input, validate_dimension, validate_volume_level
 
 
 class TestParseTimeInput(unittest.TestCase):
@@ -43,6 +43,32 @@ class TestValidateDimension(unittest.TestCase):
 
     def test_boundary_high(self):
         self.assertEqual(validate_dimension("7680", "幅"), 7680)
+
+
+class TestValidateVolumeLevel(unittest.TestCase):
+    def test_valid_float(self):
+        self.assertAlmostEqual(validate_volume_level("1.5", "音量"), 1.5)
+
+    def test_valid_integer_string(self):
+        self.assertAlmostEqual(validate_volume_level("2", "音量"), 2.0)
+
+    def test_boundary_zero(self):
+        self.assertAlmostEqual(validate_volume_level("0.0", "音量"), 0.0)
+
+    def test_boundary_max(self):
+        self.assertAlmostEqual(validate_volume_level("10.0", "音量"), 10.0)
+
+    def test_invalid_text(self):
+        with self.assertRaises(ValidationError):
+            validate_volume_level("abc", "音量")
+
+    def test_too_small(self):
+        with self.assertRaises(ValidationError):
+            validate_volume_level("-0.1", "音量")
+
+    def test_too_large(self):
+        with self.assertRaises(ValidationError):
+            validate_volume_level("10.1", "音量")
 
 
 if __name__ == "__main__":

--- a/tests/test_volume_flow.py
+++ b/tests/test_volume_flow.py
@@ -1,0 +1,226 @@
+import unittest
+from unittest.mock import patch
+
+from usecases.flow_result import FlowResult
+from usecases.volume_flow import (
+    VolumeForm,
+    execute_volume,
+    handle_volume_review,
+    run_volume_iteration,
+)
+
+
+class TestHandleVolumeReview(unittest.TestCase):
+    @patch("usecases.shared_flow.ask_review_action", return_value="cancel")
+    def test_handle_volume_review_cancel(self, _mock_action):
+        form = VolumeForm()
+        result = handle_volume_review(form)
+
+        self.assertEqual(result.kind, "done")
+        self.assertEqual(result.form, form)
+
+    @patch("usecases.shared_flow.ask_review_action", return_value="restart")
+    def test_handle_volume_review_restart(self, _mock_action):
+        form = VolumeForm(
+            input_file="in.mp4",
+            volume_raw="2.0",
+            output_file="out.mp4",
+        )
+        result = handle_volume_review(form)
+
+        self.assertEqual(result.kind, "retry")
+        self.assertEqual(result.form, VolumeForm())
+
+    @patch("usecases.shared_flow.ask_review_action", return_value="execute")
+    def test_handle_volume_review_execute(self, _mock_action):
+        form = VolumeForm(
+            input_file="in.mp4",
+            volume_raw="2.0",
+            output_file="out.mp4",
+        )
+        result = handle_volume_review(form)
+
+        self.assertEqual(result.kind, "execute")
+        self.assertEqual(result.form, form)
+
+    @patch("usecases.shared_flow.ask_review_action", return_value="dry_run")
+    def test_handle_volume_review_dry_run(self, _mock_action):
+        form = VolumeForm(
+            input_file="in.mp4",
+            volume_raw="2.0",
+            output_file="out.mp4",
+        )
+        result = handle_volume_review(form)
+
+        self.assertEqual(result.kind, "dry_run")
+        self.assertEqual(result.form, form)
+
+    @patch("usecases.shared_flow.ask_review_action", return_value="edit")
+    @patch("usecases.volume_flow.edit_volume_form")
+    def test_handle_volume_review_edit(self, mock_edit_form, _mock_action):
+        form = VolumeForm(
+            input_file="in.mp4",
+            volume_raw="2.0",
+            output_file="out.mp4",
+        )
+        edited = VolumeForm(
+            input_file="in.mp4",
+            volume_raw="1.5",
+            output_file="out.mp4",
+        )
+        mock_edit_form.return_value = edited
+
+        result = handle_volume_review(form)
+
+        self.assertEqual(result.kind, "retry")
+        self.assertEqual(result.form, edited)
+        mock_edit_form.assert_called_once_with(form)
+
+
+class TestExecuteVolume(unittest.TestCase):
+    @patch("usecases.volume_flow.run_ffmpeg")
+    @patch("usecases.volume_flow.build_volume_command")
+    def test_execute_volume_runs_command(self, mock_build_volume_command, mock_run_ffmpeg):
+        form = VolumeForm(
+            input_file="in.mp4",
+            volume_raw="1.5",
+            output_file="out.mp4",
+        )
+        mock_build_volume_command.return_value = ["ffmpeg", "..."]
+
+        execute_volume(form)
+
+        mock_build_volume_command.assert_called_once_with(
+            input_file="in.mp4",
+            output_file="out.mp4",
+            volume_level=1.5,
+        )
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+
+    @patch("usecases.volume_flow.run_ffmpeg")
+    @patch("usecases.volume_flow.build_volume_command")
+    def test_execute_volume_dry_run(self, mock_build_volume_command, mock_run_ffmpeg):
+        form = VolumeForm(
+            input_file="in.mp4",
+            volume_raw="1.5",
+            output_file="out.mp4",
+        )
+        mock_build_volume_command.return_value = ["ffmpeg", "..."]
+
+        execute_volume(form, dry_run=True)
+
+        mock_build_volume_command.assert_called_once_with(
+            input_file="in.mp4",
+            output_file="out.mp4",
+            volume_level=1.5,
+        )
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+
+
+class TestRunVolumeIteration(unittest.TestCase):
+    @patch("usecases.volume_flow.collect_volume_input")
+    @patch("usecases.volume_flow.build_volume_summary")
+    @patch("usecases.shared_flow.handle_generic_review")
+    @patch("usecases.volume_flow.execute_volume")
+    def test_run_volume_iteration_execute_path(
+        self,
+        mock_execute_volume,
+        mock_handle_review,
+        mock_build_volume_summary,
+        mock_collect_volume_input,
+    ):
+        form = VolumeForm()
+        updated_form = VolumeForm(
+            input_file="in.mp4",
+            volume_raw="2.0",
+            output_file="out.mp4",
+        )
+        media_info = object()
+
+        mock_collect_volume_input.return_value = (updated_form, media_info)
+        mock_build_volume_summary.return_value = "summary"
+        mock_handle_review.return_value = FlowResult(kind="execute", form=updated_form)
+
+        result = run_volume_iteration(form)
+
+        self.assertEqual(result.kind, "done")
+        self.assertEqual(result.form, updated_form)
+        mock_execute_volume.assert_called_once_with(updated_form, dry_run=False)
+
+    @patch("usecases.volume_flow.collect_volume_input")
+    @patch("usecases.volume_flow.build_volume_summary")
+    @patch("usecases.shared_flow.handle_generic_review")
+    @patch("usecases.volume_flow.execute_volume")
+    def test_run_volume_iteration_dry_run_path(
+        self,
+        mock_execute_volume,
+        mock_handle_review,
+        mock_build_volume_summary,
+        mock_collect_volume_input,
+    ):
+        form = VolumeForm()
+        updated_form = VolumeForm(
+            input_file="in.mp4",
+            volume_raw="2.0",
+            output_file="out.mp4",
+        )
+        media_info = object()
+
+        mock_collect_volume_input.return_value = (updated_form, media_info)
+        mock_build_volume_summary.return_value = "summary"
+        mock_handle_review.return_value = FlowResult(kind="dry_run", form=updated_form)
+
+        result = run_volume_iteration(form)
+
+        self.assertEqual(result.kind, "done")
+        self.assertEqual(result.form, updated_form)
+        mock_execute_volume.assert_called_once_with(updated_form, dry_run=True)
+
+    @patch("usecases.volume_flow.collect_volume_input")
+    @patch("usecases.volume_flow.build_volume_summary")
+    @patch("usecases.shared_flow.handle_generic_review")
+    @patch("usecases.volume_flow.execute_volume")
+    def test_run_volume_iteration_retry_path(
+        self,
+        mock_execute_volume,
+        mock_handle_review,
+        mock_build_volume_summary,
+        mock_collect_volume_input,
+    ):
+        form = VolumeForm()
+        updated_form = VolumeForm(
+            input_file="in.mp4",
+            volume_raw="2.0",
+            output_file="out.mp4",
+        )
+        media_info = object()
+
+        mock_collect_volume_input.return_value = (updated_form, media_info)
+        mock_build_volume_summary.return_value = "summary"
+        mock_handle_review.return_value = FlowResult(kind="retry", form=updated_form)
+
+        result = run_volume_iteration(form)
+
+        self.assertEqual(result.kind, "retry")
+        self.assertEqual(result.form, updated_form)
+        mock_execute_volume.assert_not_called()
+
+    @patch("usecases.volume_flow.collect_volume_input")
+    def test_run_volume_iteration_validation_error_returns_retry(self, mock_collect_volume_input):
+        from shared.errors import ValidationError
+
+        form = VolumeForm(
+            input_file="in.mp4",
+            volume_raw="2.0",
+            output_file="out.mp4",
+        )
+        mock_collect_volume_input.side_effect = ValidationError("bad input")
+
+        result = run_volume_iteration(form)
+
+        self.assertEqual(result.kind, "retry")
+        self.assertEqual(result.form, form)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -9,6 +9,7 @@ def prompt_main_menu() -> str:
             ("動画を切り出す", operations.TRIM),
             ("動画を結合する", operations.CONCAT),
             ("動画サイズを変更する", operations.RESIZE),
+            ("音量を調整する", operations.VOLUME),
             ("終了する", operations.EXIT),
         ],
     )

--- a/usecases/volume_flow.py
+++ b/usecases/volume_flow.py
@@ -1,0 +1,153 @@
+from dataclasses import dataclass, replace
+
+from ffmpeg.commands import build_volume_command
+from ffmpeg.probe import probe_media_info
+from ffmpeg.runner import run_ffmpeg
+from shared.command_formatter import format_command
+from shared.formatters import format_media_info_summary
+from ui.prompts import ask_text, require_non_empty
+from ui.review import ask_field_to_edit
+from usecases.flow_result import FlowResult
+from usecases.shared_flow import handle_generic_review, run_flow, run_generic_iteration
+from validation.file_validators import (
+    validate_input_file_exists,
+    validate_output_directory_exists,
+    validate_video_file_extension,
+)
+from validation.value_validators import validate_volume_level
+
+
+@dataclass
+class VolumeForm:
+    input_file: str = "./input.mp4"
+    volume_raw: str = "1.5"
+    output_file: str = "./output-volume.mp4"
+
+
+def ask_volume_input_file(default_value: str) -> str:
+    return require_non_empty(
+        ask_text(
+            "対象の動画ファイルを入力してください\n例: ./input/video.mp4",
+            default=default_value,
+        ),
+        "入力ファイル",
+    )
+
+
+def ask_volume_level(default_value: str) -> str:
+    return require_non_empty(
+        ask_text(
+            "音量倍率を入力してください\n数値: 0.0〜10.0（1.0=元の音量、2.0=2倍、0.5=半分）\n例: 1.5",
+            default=default_value,
+        ),
+        "音量倍率",
+    )
+
+
+def ask_volume_output(default_value: str) -> str:
+    return require_non_empty(
+        ask_text(
+            "出力ファイル名を入力してください\n例: ./output/volume-adjusted.mp4",
+            default=default_value,
+        ),
+        "出力ファイル",
+    )
+
+
+def collect_volume_input(form: VolumeForm):
+    input_file = ask_volume_input_file(form.input_file)
+    validate_input_file_exists(input_file)
+    validate_video_file_extension(input_file)
+
+    media_info = probe_media_info(input_file)
+    print("\n入力動画情報:")
+    print(format_media_info_summary(media_info))
+    print()
+
+    volume_raw = ask_volume_level(form.volume_raw)
+    validate_volume_level(volume_raw, "音量倍率")
+
+    output_file = ask_volume_output(form.output_file)
+    validate_output_directory_exists(output_file)
+
+    return replace(
+        form,
+        input_file=input_file,
+        volume_raw=volume_raw,
+        output_file=output_file,
+    ), media_info
+
+
+def build_volume_summary(form: VolumeForm, media_info) -> str:
+    current_volume = "不明"
+    if media_info.audio:
+        current_volume = media_info.audio.codec_name
+    return "\n".join(
+        [
+            "実行内容:",
+            "- 操作: 音量調整",
+            f"- 入力: {form.input_file}",
+            f"- 音声コーデック: {current_volume}",
+            f"- 音量倍率: {form.volume_raw}",
+            f"- 出力: {form.output_file}",
+        ]
+    )
+
+
+def edit_volume_form(form: VolumeForm) -> VolumeForm:
+    field = ask_field_to_edit(
+        [
+            ("入力ファイル", "input_file"),
+            ("音量倍率", "volume_raw"),
+            ("出力ファイル", "output_file"),
+        ]
+    )
+
+    prompts = {
+        "input_file": ("入力ファイルを再入力してください", "入力ファイル"),
+        "volume_raw": ("音量倍率を再入力してください", "音量倍率"),
+        "output_file": ("出力ファイルを再入力してください", "出力ファイル"),
+    }
+    prompt, label = prompts[field]
+    value = require_non_empty(ask_text(prompt, default=getattr(form, field)), label)
+    return replace(form, **{field: value})
+
+
+def handle_volume_review(form: VolumeForm) -> FlowResult:
+    return handle_generic_review(form, VolumeForm, edit_volume_form)
+
+
+def execute_volume(form: VolumeForm, dry_run: bool = False) -> None:
+    volume_level = validate_volume_level(form.volume_raw, "音量倍率")
+
+    command = build_volume_command(
+        input_file=form.input_file,
+        output_file=form.output_file,
+        volume_level=volume_level,
+    )
+
+    print("生成された FFmpeg コマンド:")
+    print(format_command(command))
+    print()
+
+    result = run_ffmpeg(command, dry_run=dry_run)
+
+    if result.executed:
+        print(f"完了: {form.output_file}")
+    else:
+        print("ドライラン完了: 実行はしていません。")
+
+
+def run_volume_iteration(form: VolumeForm) -> FlowResult:
+    return run_generic_iteration(
+        form,
+        collect_volume_input,
+        build_volume_summary,
+        VolumeForm,
+        edit_volume_form,
+        execute_volume,
+    )
+
+
+def run_volume_flow() -> None:
+    run_flow(VolumeForm(), run_volume_iteration)

--- a/validation/value_validators.py
+++ b/validation/value_validators.py
@@ -46,3 +46,15 @@ def validate_dimension(raw: str, label: str) -> int:
         raise ValidationError(f"{label} は 16〜7680 の範囲で入力してください。")
 
     return value
+
+
+def validate_volume_level(raw: str, label: str) -> float:
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValidationError(f"{label} は数値で入力してください。") from exc
+
+    if value < 0.0 or value > 10.0:
+        raise ValidationError(f"{label} は 0.0〜10.0 の範囲で入力してください。")
+
+    return value


### PR DESCRIPTION
## 概要
- FFmpeg の `-filter:a "volume=N"` を使った音量調整機能を追加
- 映像は `-c:v copy` で無劣化コピー（音声フィルタのみ適用）
- 倍率入力: 0.0〜10.0（1.0=元の音量、2.0=2倍、0.5=半分）

## 変更ファイル
- `domain/operations.py` — `VOLUME` 定数追加
- `validation/value_validators.py` — `validate_volume_level` 追加
- `ui/main_menu.py` — 「音量を調整する」メニュー項目追加
- `ffmpeg/commands.py` — `build_volume_command` 追加
- `usecases/volume_flow.py` — 新規作成（VolumeForm + フロー全体）
- `main.py` — ハンドラ登録

## テスト
- 全 146 テスト通過
- TDD（Red→Green）で実装

## 動作確認チェックリスト
- [ ] `uv run python main.py` でメニューに「音量を調整する」が表示される
- [ ] 入力ファイル → 倍率（例: 2.0）→ dry-run でコマンド確認できる
- [ ] 期待コマンド: `ffmpeg -y -i input.mp4 -filter:a volume=2.0 -c:v copy output.mp4`

closes #16