### PR TITLE
fix: ミュートコマンドの映像再エンコードを防ぐ

### DIFF
--- a/ffmpeg/commands.py
+++ b/ffmpeg/commands.py
@@ -148,7 +148,7 @@ def build_rotate_command(input_file: str, output_file: str, direction: str) -> l
 
 
 def build_mute_command(input_file: str, output_file: str) -> list[str]:
-    return ["ffmpeg", "-y", "-i", input_file, "-an", output_file]
+    return ["ffmpeg", "-y", "-i", input_file, "-an", "-c:v", "copy", output_file]
 
 
 def build_audio_extract_command(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -283,12 +283,17 @@ class TestBuildMuteCommand(unittest.TestCase):
         command = build_mute_command("in.mp4", "out.mp4")
         self.assertEqual(
             command,
-            ["ffmpeg", "-y", "-i", "in.mp4", "-an", "out.mp4"],
+            ["ffmpeg", "-y", "-i", "in.mp4", "-an", "-c:v", "copy", "out.mp4"],
         )
 
     def test_no_audio_flag(self):
         command = build_mute_command("in.mp4", "out.mp4")
         self.assertIn("-an", command)
+
+    def test_video_stream_copied(self):
+        command = build_mute_command("in.mp4", "out.mp4")
+        copy_idx = command.index("copy")
+        self.assertEqual(command[copy_idx - 1], "-c:v")
 
     def test_video_stream_preserved(self):
         command = build_mute_command("in.mp4", "out.mp4")


### PR DESCRIPTION
## 問題

`-an` のみだと mp4 等への出力時に ffmpeg がデフォルトで映像を再エンコードする。
音声削除だけの操作なのに映像が再エンコードされ、速度低下・品質劣化が起きうる。

## 修正

`-c:v copy` を明示追加して映像ストリームをコピーするよう変更。

```
# before
ffmpeg -y -i input.mp4 -an output.mp4

# after
ffmpeg -y -i input.mp4 -an -c:v copy output.mp4
```

closes #35

## Test plan

- [x] `uv run pytest` 290テスト全通過
- [x] `test_video_stream_copied` テスト追加で `-c:v copy` の存在を明示検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)