### PR TITLE
create_concat_list_file() をコンテキストマネージャー化する

### DIFF
--- a/ffmpeg/commands.py
+++ b/ffmpeg/commands.py
@@ -1,5 +1,7 @@
+from contextlib import contextmanager
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from typing import Generator
 
 from domain.trim_range import TrimRange
 
@@ -208,7 +210,8 @@ def build_volume_command(
     ]
 
 
-def create_concat_list_file(input_files: list[str]) -> str:
+@contextmanager
+def create_concat_list_file(input_files: list[str]) -> Generator[str, None, None]:
     temp = NamedTemporaryFile(
         mode="w",
         encoding="utf-8",
@@ -216,13 +219,14 @@ def create_concat_list_file(input_files: list[str]) -> str:
         prefix="video_cli_concat_",
         delete=False,
     )
-
     with temp:
         for file_path in input_files:
             normalized = Path(file_path).resolve().as_posix().replace("'", r"'\''")
             temp.write(f"file '{normalized}'\n")
-
-    return temp.name
+    try:
+        yield temp.name
+    finally:
+        Path(temp.name).unlink(missing_ok=True)
 
 
 def build_concat_copy_command(concat_list_file: str, output_file: str) -> list[str]:

--- a/ffmpeg/concat_strategy.py
+++ b/ffmpeg/concat_strategy.py
@@ -8,8 +8,7 @@ from ffmpeg.commands import (
 
 
 class ConcatCommandStrategy(Protocol):
-    def build(self, concat_list_file: str, output_file: str) -> list[str]:
-        ...
+    def build(self, concat_list_file: str, output_file: str) -> list[str]: ...
 
 
 @dataclass(frozen=True)

--- a/ffmpeg/probe.py
+++ b/ffmpeg/probe.py
@@ -43,9 +43,7 @@ def run_ffprobe(file_path: str) -> dict:
             check=True,
         )
     except subprocess.CalledProcessError as exc:
-        raise ValidationError(
-            f"ffprobe でメディア情報を取得できませんでした: {file_path}"
-        ) from exc
+        raise ValidationError(f"ffprobe でメディア情報を取得できませんでした: {file_path}") from exc
 
     return json.loads(result.stdout)
 

--- a/ffmpeg/runner.py
+++ b/ffmpeg/runner.py
@@ -18,10 +18,7 @@ def run_ffmpeg(command: list[str], dry_run: bool = False) -> RunResult:
     try:
         subprocess.run(command, check=True)
     except subprocess.CalledProcessError as exc:
-        detail = (
-            f"終了コード: {exc.returncode}\n"
-            f"実行コマンド: {format_command(command)}"
-        )
+        detail = f"終了コード: {exc.returncode}\n実行コマンド: {format_command(command)}"
         raise FfmpegExecutionError(
             "FFmpeg の実行に失敗しました。",
             detail=detail,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 
 from domain.trim_range import TrimRange
 from ffmpeg.commands import (
@@ -15,6 +16,7 @@ from ffmpeg.commands import (
     build_thumbnail_command,
     build_trim_command,
     build_volume_command,
+    create_concat_list_file,
 )
 
 
@@ -346,6 +348,30 @@ class TestBuildRotateCommand(unittest.TestCase):
         command = build_rotate_command("in.mp4", "out.mp4", "vflip")
         vf_idx = command.index("-vf")
         self.assertEqual(command[vf_idx + 1], "vflip")
+
+
+class TestCreateConcatListFile(unittest.TestCase):
+    def test_yields_path_with_correct_content(self):
+        input_files = ["/tmp/a.mp4", "/tmp/b.mp4"]
+        with create_concat_list_file(input_files) as path:
+            content = Path(path).read_text()
+        self.assertIn("a.mp4", content)
+        self.assertIn("b.mp4", content)
+
+    def test_deletes_file_after_with_block(self):
+        input_files = ["/tmp/a.mp4"]
+        with create_concat_list_file(input_files) as path:
+            captured_path = path
+        self.assertFalse(Path(captured_path).exists())
+
+    def test_deletes_file_even_when_exception_raised(self):
+        input_files = ["/tmp/a.mp4"]
+        captured_path = None
+        with self.assertRaises(RuntimeError):
+            with create_concat_list_file(input_files) as path:
+                captured_path = path
+                raise RuntimeError("test error")
+        self.assertFalse(Path(captured_path).exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_concat_flow.py
+++ b/tests/test_concat_flow.py
@@ -10,7 +10,6 @@ from usecases.flow_result import FlowResult
 
 
 class TestExecuteConcat(unittest.TestCase):
-    @patch("usecases.concat_flow.Path")
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.concat_flow.choose_concat_strategy")
     @patch("usecases.concat_flow.create_concat_list_file")
@@ -19,7 +18,6 @@ class TestExecuteConcat(unittest.TestCase):
         mock_create_concat_list_file,
         mock_choose_concat_strategy,
         mock_run_ffmpeg,
-        mock_path_cls,
     ):
         form = ConcatForm(
             count_raw="2",
@@ -27,7 +25,8 @@ class TestExecuteConcat(unittest.TestCase):
             output_file="out.mp4",
         )
 
-        mock_create_concat_list_file.return_value = "/tmp/list.txt"
+        mock_create_concat_list_file.return_value.__enter__ = MagicMock(return_value="/tmp/list.txt")
+        mock_create_concat_list_file.return_value.__exit__ = MagicMock(return_value=False)
 
         strategy = MagicMock()
         strategy.build.return_value = ["ffmpeg", "..."]
@@ -37,19 +36,13 @@ class TestExecuteConcat(unittest.TestCase):
         mock_result.executed = True
         mock_run_ffmpeg.return_value = mock_result
 
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        mock_path_cls.return_value = mock_path
-
         execute_concat(form, compatible=True)
 
         mock_create_concat_list_file.assert_called_once_with(["a.mp4", "b.mp4"])
         mock_choose_concat_strategy.assert_called_once_with(True)
         strategy.build.assert_called_once_with("/tmp/list.txt", "out.mp4")
         mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
-        mock_path.unlink.assert_called_once()
 
-    @patch("usecases.concat_flow.Path")
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.concat_flow.choose_concat_strategy")
     @patch("usecases.concat_flow.create_concat_list_file")
@@ -58,7 +51,6 @@ class TestExecuteConcat(unittest.TestCase):
         mock_create_concat_list_file,
         mock_choose_concat_strategy,
         mock_run_ffmpeg,
-        mock_path_cls,
     ):
         form = ConcatForm(
             count_raw="2",
@@ -66,7 +58,8 @@ class TestExecuteConcat(unittest.TestCase):
             output_file="out.mp4",
         )
 
-        mock_create_concat_list_file.return_value = "/tmp/list.txt"
+        mock_create_concat_list_file.return_value.__enter__ = MagicMock(return_value="/tmp/list.txt")
+        mock_create_concat_list_file.return_value.__exit__ = MagicMock(return_value=False)
 
         strategy = MagicMock()
         strategy.build.return_value = ["ffmpeg", "..."]
@@ -76,19 +69,13 @@ class TestExecuteConcat(unittest.TestCase):
         mock_result.executed = False
         mock_run_ffmpeg.return_value = mock_result
 
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        mock_path_cls.return_value = mock_path
-
         execute_concat(form, compatible=True, dry_run=True)
 
         mock_create_concat_list_file.assert_called_once_with(["a.mp4", "b.mp4"])
         mock_choose_concat_strategy.assert_called_once_with(True)
         strategy.build.assert_called_once_with("/tmp/list.txt", "out.mp4")
         mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
-        mock_path.unlink.assert_called_once()
 
-    @patch("usecases.concat_flow.Path")
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.concat_flow.choose_concat_strategy")
     @patch("usecases.concat_flow.create_concat_list_file")
@@ -97,7 +84,6 @@ class TestExecuteConcat(unittest.TestCase):
         mock_create_concat_list_file,
         mock_choose_concat_strategy,
         mock_run_ffmpeg,
-        mock_path_cls,
     ):
         from shared.errors import FfmpegExecutionError
 
@@ -107,7 +93,8 @@ class TestExecuteConcat(unittest.TestCase):
             output_file="out.mp4",
         )
 
-        mock_create_concat_list_file.return_value = "/tmp/list.txt"
+        mock_create_concat_list_file.return_value.__enter__ = MagicMock(return_value="/tmp/list.txt")
+        mock_create_concat_list_file.return_value.__exit__ = MagicMock(return_value=False)
 
         strategy = MagicMock()
         strategy.build.return_value = ["ffmpeg", "..."]
@@ -115,14 +102,10 @@ class TestExecuteConcat(unittest.TestCase):
 
         mock_run_ffmpeg.side_effect = FfmpegExecutionError("failed")
 
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        mock_path_cls.return_value = mock_path
-
         with self.assertRaises(FfmpegExecutionError):
             execute_concat(form, compatible=False)
 
-        mock_path.unlink.assert_called_once()
+        mock_create_concat_list_file.return_value.__exit__.assert_called_once()
 
 
 class TestRunConcatIteration(unittest.TestCase):

--- a/tests/test_convert_flow.py
+++ b/tests/test_convert_flow.py
@@ -84,6 +84,7 @@ class TestRunConvertIteration(unittest.TestCase):
     @patch("usecases.convert_flow.collect_convert_input")
     def test_validation_error_returns_retry(self, mock_collect):
         from shared.errors import ValidationError
+
         form = ConvertForm(input_file="in.mov", output_file="out.mp4")
         mock_collect.side_effect = ValidationError("bad")
         result = run_convert_iteration(form)

--- a/tests/test_crop_flow.py
+++ b/tests/test_crop_flow.py
@@ -54,9 +54,7 @@ class TestExecuteCrop(unittest.TestCase):
         form = CropForm(input_file="in.mp4", width=640, height=360, x=0, y=0, output_file="out.mp4")
         mock_build.return_value = ["ffmpeg", "..."]
         execute_crop(form)
-        mock_build.assert_called_once_with(
-            input_file="in.mp4", output_file="out.mp4", width=640, height=360, x=0, y=0
-        )
+        mock_build.assert_called_once_with(input_file="in.mp4", output_file="out.mp4", width=640, height=360, x=0, y=0)
         mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
 
     @patch("usecases.shared_flow.run_ffmpeg")
@@ -86,6 +84,7 @@ class TestRunCropIteration(unittest.TestCase):
     @patch("usecases.crop_flow.collect_crop_input")
     def test_validation_error_returns_retry(self, mock_collect):
         from shared.errors import ValidationError
+
         form = CropForm(input_file="in.mp4", width=640, height=360, x=0, y=0, output_file="out.mp4")
         mock_collect.side_effect = ValidationError("bad")
         result = run_crop_iteration(form)

--- a/tests/test_gif_flow.py
+++ b/tests/test_gif_flow.py
@@ -98,9 +98,7 @@ class TestRunGifIteration(unittest.TestCase):
         mock_collect,
     ):
         form = GifForm()
-        updated_form = GifForm(
-            input_file="in.mp4", fps_raw="10", width_raw="480", output_file="out.gif"
-        )
+        updated_form = GifForm(input_file="in.mp4", fps_raw="10", width_raw="480", output_file="out.gif")
         media_info = object()
 
         mock_collect.return_value = (updated_form, media_info)
@@ -124,9 +122,7 @@ class TestRunGifIteration(unittest.TestCase):
         mock_collect,
     ):
         form = GifForm()
-        updated_form = GifForm(
-            input_file="in.mp4", fps_raw="10", width_raw="480", output_file="out.gif"
-        )
+        updated_form = GifForm(input_file="in.mp4", fps_raw="10", width_raw="480", output_file="out.gif")
         media_info = object()
 
         mock_collect.return_value = (updated_form, media_info)
@@ -150,9 +146,7 @@ class TestRunGifIteration(unittest.TestCase):
         mock_collect,
     ):
         form = GifForm()
-        updated_form = GifForm(
-            input_file="in.mp4", fps_raw="10", width_raw="480", output_file="out.gif"
-        )
+        updated_form = GifForm(input_file="in.mp4", fps_raw="10", width_raw="480", output_file="out.gif")
         media_info = object()
 
         mock_collect.return_value = (updated_form, media_info)

--- a/tests/test_info_flow.py
+++ b/tests/test_info_flow.py
@@ -21,6 +21,7 @@ class TestCollectInfoInput(unittest.TestCase):
     @patch("usecases.info_flow.ask_text", return_value="")
     def test_empty_input_raises(self, _mock_ask, _mock_exists):
         from shared.errors import ValidationError
+
         with self.assertRaises(ValidationError):
             collect_info_input()
 
@@ -37,6 +38,7 @@ class TestRunInfoFlow(unittest.TestCase):
     @patch("usecases.info_flow.collect_info_input")
     def test_validation_error_is_caught(self, mock_collect):
         from shared.errors import ValidationError
+
         mock_collect.side_effect = ValidationError("bad")
         run_info_flow()
 

--- a/tests/test_mute_flow.py
+++ b/tests/test_mute_flow.py
@@ -102,6 +102,7 @@ class TestRunMuteIteration(unittest.TestCase):
     @patch("usecases.mute_flow.collect_mute_input")
     def test_validation_error_returns_retry(self, mock_collect):
         from shared.errors import ValidationError
+
         form = MuteForm(input_file="in.mp4", output_file="out.mp4")
         mock_collect.side_effect = ValidationError("bad")
         result = run_mute_iteration(form)

--- a/tests/test_rotate_flow.py
+++ b/tests/test_rotate_flow.py
@@ -54,9 +54,7 @@ class TestExecuteRotate(unittest.TestCase):
         form = RotateForm(input_file="in.mp4", direction="right90", output_file="out.mp4")
         mock_build.return_value = ["ffmpeg", "..."]
         execute_rotate(form)
-        mock_build.assert_called_once_with(
-            input_file="in.mp4", output_file="out.mp4", direction="right90"
-        )
+        mock_build.assert_called_once_with(input_file="in.mp4", output_file="out.mp4", direction="right90")
         mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
 
     @patch("usecases.shared_flow.run_ffmpeg")
@@ -86,6 +84,7 @@ class TestRunRotateIteration(unittest.TestCase):
     @patch("usecases.rotate_flow.collect_rotate_input")
     def test_validation_error_returns_retry(self, mock_collect):
         from shared.errors import ValidationError
+
         form = RotateForm(input_file="in.mp4", direction="right90", output_file="out.mp4")
         mock_collect.side_effect = ValidationError("bad")
         result = run_rotate_iteration(form)

--- a/tests/test_thumbnail_flow.py
+++ b/tests/test_thumbnail_flow.py
@@ -97,9 +97,7 @@ class TestRunThumbnailIteration(unittest.TestCase):
         mock_collect,
     ):
         form = ThumbnailForm()
-        updated_form = ThumbnailForm(
-            input_file="in.mp4", timestamp_raw="10", output_file="out.jpg"
-        )
+        updated_form = ThumbnailForm(input_file="in.mp4", timestamp_raw="10", output_file="out.jpg")
         media_info = object()
 
         mock_collect.return_value = (updated_form, media_info)
@@ -123,9 +121,7 @@ class TestRunThumbnailIteration(unittest.TestCase):
         mock_collect,
     ):
         form = ThumbnailForm()
-        updated_form = ThumbnailForm(
-            input_file="in.mp4", timestamp_raw="10", output_file="out.jpg"
-        )
+        updated_form = ThumbnailForm(input_file="in.mp4", timestamp_raw="10", output_file="out.jpg")
         media_info = object()
 
         mock_collect.return_value = (updated_form, media_info)
@@ -149,9 +145,7 @@ class TestRunThumbnailIteration(unittest.TestCase):
         mock_collect,
     ):
         form = ThumbnailForm()
-        updated_form = ThumbnailForm(
-            input_file="in.mp4", timestamp_raw="10", output_file="out.jpg"
-        )
+        updated_form = ThumbnailForm(input_file="in.mp4", timestamp_raw="10", output_file="out.jpg")
         media_info = object()
 
         mock_collect.return_value = (updated_form, media_info)

--- a/usecases/concat_flow.py
+++ b/usecases/concat_flow.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field, replace
-from pathlib import Path
 
 from ffmpeg.commands import create_concat_list_file
 from ffmpeg.concat_strategy import choose_concat_strategy
@@ -90,12 +89,16 @@ def collect_concat_input(form: ConcatForm):
     media_infos = [probe_media_info(path) for path in input_files]
     compatible = are_concat_streams_compatible(media_infos)
 
-    return replace(
-        form,
-        count_raw=count_raw,
-        input_files=input_files,
-        output_file=output_file,
-    ), media_infos, compatible
+    return (
+        replace(
+            form,
+            count_raw=count_raw,
+            input_files=input_files,
+            output_file=output_file,
+        ),
+        media_infos,
+        compatible,
+    )
 
 
 def format_media_info_block(media_info) -> str:
@@ -155,7 +158,6 @@ def edit_concat_form(form: ConcatForm) -> ConcatForm:
     return replace(form, input_files=update_concat_file(form.input_files, index, value))
 
 
-
 def build_concat_command(
     form: ConcatForm,
     compatible: bool,
@@ -166,14 +168,9 @@ def build_concat_command(
 
 
 def execute_concat(form: ConcatForm, compatible: bool, dry_run: bool = False) -> None:
-    concat_list_file = create_concat_list_file(form.input_files)
-
-    try:
+    with create_concat_list_file(form.input_files) as concat_list_file:
         command = build_concat_command(form, compatible, concat_list_file)
         execute_with_output(command, form.output_file, dry_run)
-    finally:
-        path = Path(concat_list_file)
-        path.unlink(missing_ok=True)
 
 
 def run_concat_iteration(form: ConcatForm) -> FlowResult:

--- a/usecases/convert_flow.py
+++ b/usecases/convert_flow.py
@@ -55,22 +55,27 @@ def collect_convert_input(form: ConvertForm):
 
 def build_convert_summary(form: ConvertForm, media_info) -> str:
     from pathlib import Path
+
     in_ext = Path(form.input_file).suffix.upper().lstrip(".")
     out_ext = Path(form.output_file).suffix.upper().lstrip(".")
-    return "\n".join([
-        "実行内容:",
-        "- 操作: フォーマット変換（再エンコードなし）",
-        f"- 入力: {form.input_file}",
-        f"- 変換: {in_ext} → {out_ext}",
-        f"- 出力: {form.output_file}",
-    ])
+    return "\n".join(
+        [
+            "実行内容:",
+            "- 操作: フォーマット変換（再エンコードなし）",
+            f"- 入力: {form.input_file}",
+            f"- 変換: {in_ext} → {out_ext}",
+            f"- 出力: {form.output_file}",
+        ]
+    )
 
 
 def edit_convert_form(form: ConvertForm) -> ConvertForm:
-    field = ask_field_to_edit([
-        ("入力ファイル", "input_file"),
-        ("出力ファイル", "output_file"),
-    ])
+    field = ask_field_to_edit(
+        [
+            ("入力ファイル", "input_file"),
+            ("出力ファイル", "output_file"),
+        ]
+    )
     prompts = {
         "input_file": ("入力ファイルを再入力してください", "入力ファイル"),
         "output_file": ("出力ファイルを再入力してください", "出力ファイル"),
@@ -92,7 +97,12 @@ def execute_convert(form: ConvertForm, dry_run: bool = False) -> None:
 
 def run_convert_iteration(form: ConvertForm) -> FlowResult:
     return run_generic_iteration(
-        form, collect_convert_input, build_convert_summary, ConvertForm, edit_convert_form, execute_convert,
+        form,
+        collect_convert_input,
+        build_convert_summary,
+        ConvertForm,
+        edit_convert_form,
+        execute_convert,
     )
 
 

--- a/usecases/crop_flow.py
+++ b/usecases/crop_flow.py
@@ -62,24 +62,28 @@ def collect_crop_input(form: CropForm):
 
 
 def build_crop_summary(form: CropForm, media_info) -> str:
-    return "\n".join([
-        "実行内容:",
-        "- 操作: クロップ",
-        f"- 入力: {form.input_file}",
-        f"- クロップ範囲: {form.width}x{form.height} (x={form.x}, y={form.y})",
-        f"- 出力: {form.output_file}",
-    ])
+    return "\n".join(
+        [
+            "実行内容:",
+            "- 操作: クロップ",
+            f"- 入力: {form.input_file}",
+            f"- クロップ範囲: {form.width}x{form.height} (x={form.x}, y={form.y})",
+            f"- 出力: {form.output_file}",
+        ]
+    )
 
 
 def edit_crop_form(form: CropForm) -> CropForm:
-    field = ask_field_to_edit([
-        ("入力ファイル", "input_file"),
-        ("幅", "width"),
-        ("高さ", "height"),
-        ("X座標", "x"),
-        ("Y座標", "y"),
-        ("出力ファイル", "output_file"),
-    ])
+    field = ask_field_to_edit(
+        [
+            ("入力ファイル", "input_file"),
+            ("幅", "width"),
+            ("高さ", "height"),
+            ("X座標", "x"),
+            ("Y座標", "y"),
+            ("出力ファイル", "output_file"),
+        ]
+    )
     if field in ("width", "height"):
         raw = ask_text(f"{field} を再入力してください", default=str(getattr(form, field)))
         value = validate_crop_dimension(raw, field)
@@ -114,7 +118,12 @@ def execute_crop(form: CropForm, dry_run: bool = False) -> None:
 
 def run_crop_iteration(form: CropForm) -> FlowResult:
     return run_generic_iteration(
-        form, collect_crop_input, build_crop_summary, CropForm, edit_crop_form, execute_crop,
+        form,
+        collect_crop_input,
+        build_crop_summary,
+        CropForm,
+        edit_crop_form,
+        execute_crop,
     )
 
 

--- a/usecases/mute_flow.py
+++ b/usecases/mute_flow.py
@@ -52,20 +52,24 @@ def collect_mute_input(form: MuteForm):
 
 def build_mute_summary(form: MuteForm, media_info) -> str:
     audio_info = media_info.audio.codec_name if media_info.audio else "なし"
-    return "\n".join([
-        "実行内容:",
-        "- 操作: 音声削除",
-        f"- 入力: {form.input_file}",
-        f"- 削除する音声コーデック: {audio_info}",
-        f"- 出力: {form.output_file}",
-    ])
+    return "\n".join(
+        [
+            "実行内容:",
+            "- 操作: 音声削除",
+            f"- 入力: {form.input_file}",
+            f"- 削除する音声コーデック: {audio_info}",
+            f"- 出力: {form.output_file}",
+        ]
+    )
 
 
 def edit_mute_form(form: MuteForm) -> MuteForm:
-    field = ask_field_to_edit([
-        ("入力ファイル", "input_file"),
-        ("出力ファイル", "output_file"),
-    ])
+    field = ask_field_to_edit(
+        [
+            ("入力ファイル", "input_file"),
+            ("出力ファイル", "output_file"),
+        ]
+    )
     prompts = {
         "input_file": ("入力ファイルを再入力してください", "入力ファイル"),
         "output_file": ("出力ファイルを再入力してください", "出力ファイル"),
@@ -87,7 +91,12 @@ def execute_mute(form: MuteForm, dry_run: bool = False) -> None:
 
 def run_mute_iteration(form: MuteForm) -> FlowResult:
     return run_generic_iteration(
-        form, collect_mute_input, build_mute_summary, MuteForm, edit_mute_form, execute_mute,
+        form,
+        collect_mute_input,
+        build_mute_summary,
+        MuteForm,
+        edit_mute_form,
+        execute_mute,
     )
 
 

--- a/usecases/rotate_flow.py
+++ b/usecases/rotate_flow.py
@@ -74,21 +74,25 @@ def collect_rotate_input(form: RotateForm):
 
 
 def build_rotate_summary(form: RotateForm, media_info) -> str:
-    return "\n".join([
-        "実行内容:",
-        "- 操作: 回転・反転",
-        f"- 入力: {form.input_file}",
-        f"- 方向: {_DIRECTION_DISPLAY.get(form.direction, form.direction)}（{ROTATE_FILTERS[form.direction]}）",
-        f"- 出力: {form.output_file}",
-    ])
+    return "\n".join(
+        [
+            "実行内容:",
+            "- 操作: 回転・反転",
+            f"- 入力: {form.input_file}",
+            f"- 方向: {_DIRECTION_DISPLAY.get(form.direction, form.direction)}（{ROTATE_FILTERS[form.direction]}）",
+            f"- 出力: {form.output_file}",
+        ]
+    )
 
 
 def edit_rotate_form(form: RotateForm) -> RotateForm:
-    field = ask_field_to_edit([
-        ("入力ファイル", "input_file"),
-        ("方向", "direction"),
-        ("出力ファイル", "output_file"),
-    ])
+    field = ask_field_to_edit(
+        [
+            ("入力ファイル", "input_file"),
+            ("方向", "direction"),
+            ("出力ファイル", "output_file"),
+        ]
+    )
     if field == "direction":
         value = ask_rotate_direction(form.direction)
     else:
@@ -106,16 +110,19 @@ def handle_rotate_review(form: RotateForm) -> FlowResult:
 
 
 def execute_rotate(form: RotateForm, dry_run: bool = False) -> None:
-    command = build_rotate_command(
-        input_file=form.input_file, output_file=form.output_file, direction=form.direction
-    )
+    command = build_rotate_command(input_file=form.input_file, output_file=form.output_file, direction=form.direction)
 
     execute_with_output(command, form.output_file, dry_run)
 
 
 def run_rotate_iteration(form: RotateForm) -> FlowResult:
     return run_generic_iteration(
-        form, collect_rotate_input, build_rotate_summary, RotateForm, edit_rotate_form, execute_rotate,
+        form,
+        collect_rotate_input,
+        build_rotate_summary,
+        RotateForm,
+        edit_rotate_form,
+        execute_rotate,
     )
 
 

--- a/usecases/thumbnail_flow.py
+++ b/usecases/thumbnail_flow.py
@@ -120,6 +120,7 @@ def handle_thumbnail_review(form: ThumbnailForm) -> FlowResult:
 
 def execute_thumbnail(form: ThumbnailForm, dry_run: bool = False) -> None:
     from validation.value_validators import parse_time_input
+
     timestamp_seconds = parse_time_input(form.timestamp_raw)
 
     command = build_thumbnail_command(

--- a/validation/file_validators.py
+++ b/validation/file_validators.py
@@ -23,44 +23,34 @@ def validate_video_file_extension(file_path: str) -> None:
     ext = Path(file_path).suffix.lower()
     if ext not in SUPPORTED_VIDEO_EXTENSIONS:
         supported = ", ".join(sorted(SUPPORTED_VIDEO_EXTENSIONS))
-        raise ValidationError(
-            f"対応していない動画拡張子です: {ext}\n対応形式: {supported}"
-        )
+        raise ValidationError(f"対応していない動画拡張子です: {ext}\n対応形式: {supported}")
 
 
 def validate_audio_output_extension(file_path: str) -> None:
     ext = Path(file_path).suffix.lower()
     if ext not in SUPPORTED_AUDIO_EXTENSIONS:
         supported = ", ".join(sorted(SUPPORTED_AUDIO_EXTENSIONS))
-        raise ValidationError(
-            f"対応していない音声拡張子です: {ext}\n対応形式: {supported}"
-        )
+        raise ValidationError(f"対応していない音声拡張子です: {ext}\n対応形式: {supported}")
 
 
 def validate_different_extension(input_file: str, output_file: str) -> None:
     in_ext = Path(input_file).suffix.lower()
     out_ext = Path(output_file).suffix.lower()
     if in_ext == out_ext:
-        raise ValidationError(
-            f"入力と出力の拡張子が同じです: {in_ext}\n変換するには異なる拡張子を指定してください。"
-        )
+        raise ValidationError(f"入力と出力の拡張子が同じです: {in_ext}\n変換するには異なる拡張子を指定してください。")
 
 
 def validate_gif_output_extension(file_path: str) -> None:
     ext = Path(file_path).suffix.lower()
     if ext not in SUPPORTED_GIF_EXTENSIONS:
-        raise ValidationError(
-            f"対応していない拡張子です: {ext}\n対応形式: .gif"
-        )
+        raise ValidationError(f"対応していない拡張子です: {ext}\n対応形式: .gif")
 
 
 def validate_image_output_extension(file_path: str) -> None:
     ext = Path(file_path).suffix.lower()
     if ext not in SUPPORTED_IMAGE_EXTENSIONS:
         supported = ", ".join(sorted(SUPPORTED_IMAGE_EXTENSIONS))
-        raise ValidationError(
-            f"対応していない画像拡張子です: {ext}\n対応形式: {supported}"
-        )
+        raise ValidationError(f"対応していない画像拡張子です: {ext}\n対応形式: {supported}")
 
 
 def validate_output_directory_exists(file_path: str) -> None:

--- a/validation/media_validators.py
+++ b/validation/media_validators.py
@@ -16,20 +16,13 @@ def are_concat_streams_compatible(media_infos: list[MediaInfo]) -> bool:
         return True
 
     first = MediaFingerprint.from_media_info(media_infos[0])
-    return all(
-        MediaFingerprint.from_media_info(current) == first
-        for current in media_infos[1:]
-    )
+    return all(MediaFingerprint.from_media_info(current) == first for current in media_infos[1:])
 
 
 def format_video_desc(media: MediaInfo) -> str:
     if media.video is None:
         return "なし"
-    return (
-        f"{media.video.codec_name}, "
-        f"{media.video.width}x{media.video.height}, "
-        f"{media.video.fps}"
-    )
+    return f"{media.video.codec_name}, {media.video.width}x{media.video.height}, {media.video.fps}"
 
 
 def format_audio_desc(media: MediaInfo) -> str:
@@ -54,11 +47,6 @@ def format_compatibility_verdict(compatible: bool) -> str:
 
 
 def build_concat_compatibility_report(media_infos: list[MediaInfo]) -> str:
-    entries = [
-        format_compatibility_entry(i, m)
-        for i, m in enumerate(media_infos, start=1)
-    ]
-    verdict = format_compatibility_verdict(
-        are_concat_streams_compatible(media_infos)
-    )
+    entries = [format_compatibility_entry(i, m) for i, m in enumerate(media_infos, start=1)]
+    verdict = format_compatibility_verdict(are_concat_streams_compatible(media_infos))
     return "\n".join(["結合互換性チェック結果:"] + entries + [verdict])

--- a/validation/value_validators.py
+++ b/validation/value_validators.py
@@ -87,9 +87,7 @@ def validate_speed_multiplier(raw: str, label: str) -> float:
 def validate_timestamp_within_duration(raw: str, duration_seconds: float) -> int:
     seconds = parse_time_input(raw)
     if seconds >= duration_seconds:
-        raise ValidationError(
-            f"指定秒数 ({seconds}秒) が動画の長さ ({duration_seconds:.0f}秒) 以上です。"
-        )
+        raise ValidationError(f"指定秒数 ({seconds}秒) が動画の長さ ({duration_seconds:.0f}秒) 以上です。")
     return seconds
 
 


### PR DESCRIPTION
## 概要

`create_concat_list_file()` を `@contextmanager` でラップし、`with` 構文で使えるようにした。

## 変更内容

- `ffmpeg/commands.py`: `create_concat_list_file()` を `@contextmanager` に変更、内部でファイル削除を担う
- `usecases/concat_flow.py`: `execute_concat()` の `try/finally` を `with` 構文に置き換え、不要な `Path` import も削除
- `tests/test_commands.py`: コンテキストマネージャーとしての動作（yield・クリーンアップ・例外時クリーンアップ）のテストを追加
- `tests/test_concat_flow.py`: モックをコンテキストマネージャー対応に更新
- ruff format による既存ファイルの整形

## 動作確認チェックリスト

- [x] `with` ブロック内で一時ファイルが存在する
- [x] `with` ブロック後に一時ファイルが自動削除される
- [x] 例外発生時もクリーンアップされる
- [x] `execute_concat` のドライランで正しい FFmpeg コマンドが生成される
- [x] `uv run pytest` 306 passed
- [x] `uv run ruff check .` All checks passed

closes #42