### PR TITLE
create_concat_list_file: 書き込み中の例外でも一時ファイルを確実に削除する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# AGENTS.md
+
+## プロジェクト概要
+
+FFmpeg をラップしたシンプルな動画処理 CLI ツール。
+Python 製、外部ライブラリへの実行時依存なし。パッケージ管理は `uv`。
+
+## コマンド
+
+```bash
+# アプリ起動
+uv run python main.py
+
+# テスト実行
+uv run pytest
+
+# テスト（詳細表示）
+uv run pytest -v
+```
+
+## アーキテクチャ
+
+依存の向きは一方向のみ（上位が下位を参照し、逆方向は禁止）。
+
+```
+domain/        ← ドメインモデル（MediaInfo, TrimRange など）。外部依存なし
+ffmpeg/        ← FFmpeg/ffprobe ラッパー。domain を参照
+validation/    ← 入力バリデーション。domain を参照
+shared/        ← 共通ユーティリティ（errors, formatters）
+ui/            ← プロンプト・メニュー・レビュー画面
+usecases/      ← ユースケースフロー。ffmpeg/validation/ui を組み合わせる
+main.py        ← エントリーポイント・ディスパッチ
+```
+
+## Review guidelines
+
+- 依存方向がアーキテクチャのルールに違反していないか確認する。
+- 一時ファイル・外部プロセス・例外処理でリソースリークが起きないか重視する。
+- テストが問題の再発防止として具体的な失敗条件を固定できているか確認する。
+- UI（ask_* など）は mock し、ビジネスロジックを過剰に mock していないか確認する。
+- `uv run pytest` と lint/format の実行結果、または未実行理由を確認する。
+
+## 新機能追加の手順（厳守）
+
+**ファイルを変更する前に必ず issue を作ること。**
+
+```
+1. gh ic                          # issue 作成
+2. git checkout -b chore/N-説明   # N は issue 番号
+3. テストを書いて Red を確認
+4. 実装して Green にする
+5. gh pc でPR作成
+6. gh pr checks N --watch でCI確認
+7. gh pm N でマージ
+8. git checkout main && git pull
+```
+
+## 各機能の実装パターン
+
+新機能は必ず以下の4つをセットで実装する：
+
+| ファイル | 役割 |
+|---------|------|
+| `ffmpeg/commands.py` | `build_XXX_command()` 追加 |
+| `usecases/xxx_flow.py` | `XxxForm`, `run_xxx_flow()` など |
+| `tests/test_xxx_flow.py` | フローのテスト |
+| `tests/test_commands.py` | コマンド生成のテスト |
+
+さらに `domain/operations.py`・`ui/main_menu.py`・`main.py` の3箇所を更新する。
+
+## コミットメッセージのルール
+
+**Why（なぜそうしたのか）を日本語で書く。**  
+How（どう変えたか）はコードを見ればわかるので書かない。
+
+```
+変更の要約（1行）
+
+変更した理由・背景を説明する。
+何が問題で、なぜこの変更が必要だったのかを書く。
+
+Co-Authored-By: Codex Sonnet 4.6 <noreply@anthropic.com>
+```
+
+## コードコメントのルール
+
+コメントには **Why not** を書く（なぜ他の選択肢を選ばなかったか）。  
+What/How は書かない（コードを読めばわかる）。
+
+## テストのルール
+
+- TDD: Red → Green の順番を守る
+- UI（ask_* など）は mock する。ビジネスロジックは mock しない
+- `uv run pytest` が green の状態でのみリファクタリングする
+
+## gh コマンドのエイリアス
+
+| エイリアス | 説明 |
+|-----------|------|
+| `gh ic` | issue 作成 |
+| `gh pc` | PR 作成（main へ） |
+| `gh pm N` | PR マージ＆ブランチ削除 |
+| `gh il` | issue 一覧 |
+| `gh mypr` | 自分の PR 一覧 |

--- a/ffmpeg/commands.py
+++ b/ffmpeg/commands.py
@@ -210,6 +210,18 @@ def build_volume_command(
     ]
 
 
+def escape_concat_file_path(file_path: str) -> str:
+    return Path(file_path).resolve().as_posix().replace("'", r"'\''")
+
+
+def build_concat_list_content(input_files: list[str]) -> str:
+    lines = []
+    for file_path in input_files:
+        escaped_path = escape_concat_file_path(file_path)
+        lines.append(f"file '{escaped_path}'\n")
+    return "".join(lines)
+
+
 @contextmanager
 def create_concat_list_file(input_files: list[str]) -> Generator[str, None, None]:
     temp = NamedTemporaryFile(
@@ -219,14 +231,13 @@ def create_concat_list_file(input_files: list[str]) -> Generator[str, None, None
         prefix="video_cli_concat_",
         delete=False,
     )
-    with temp:
-        for file_path in input_files:
-            normalized = Path(file_path).resolve().as_posix().replace("'", r"'\''")
-            temp.write(f"file '{normalized}'\n")
+    temp_path = Path(temp.name)
     try:
-        yield temp.name
+        with temp:
+            temp.write(build_concat_list_content(input_files))
+        yield str(temp_path)
     finally:
-        Path(temp.name).unlink(missing_ok=True)
+        temp_path.unlink(missing_ok=True)
 
 
 def build_concat_copy_command(concat_list_file: str, output_file: str) -> list[str]:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -373,6 +373,41 @@ class TestCreateConcatListFile(unittest.TestCase):
                 raise RuntimeError("test error")
         self.assertFalse(Path(captured_path).exists())
 
+    def test_deletes_file_when_write_raises(self):
+        import tempfile
+        from unittest.mock import MagicMock, patch
+
+        real_tmp = tempfile.NamedTemporaryFile(delete=False)
+        real_tmp.close()
+        real_tmp_name = real_tmp.name
+        self.addCleanup(Path(real_tmp_name).unlink, missing_ok=True)
+
+        mock_file = MagicMock()
+        mock_file.__enter__ = MagicMock(return_value=mock_file)
+        mock_file.__exit__ = MagicMock(return_value=False)
+        mock_file.write.side_effect = OSError("disk full")
+        mock_file.name = real_tmp_name
+
+        with self.assertRaises(OSError):
+            with patch("ffmpeg.commands.NamedTemporaryFile", return_value=mock_file):
+                with create_concat_list_file(["/tmp/a.mp4"]):
+                    pass
+
+        self.assertFalse(Path(real_tmp_name).exists())
+
+    def test_each_line_has_ffmpeg_file_entry_format(self):
+        with create_concat_list_file(["/tmp/a.mp4", "/tmp/b.mp4"]) as path:
+            content = Path(path).read_text()
+        lines = content.strip().split("\n")
+        self.assertEqual(len(lines), 2)
+        for line in lines:
+            self.assertRegex(line, r"^file '.*'$")
+
+    def test_single_quote_in_path_is_escaped(self):
+        with create_concat_list_file(["/tmp/it's.mp4"]) as path:
+            content = Path(path).read_text()
+        self.assertIn(r"'\''" , content)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 概要

Copilot の PR #64 レビューで指摘された一時ファイルリークを修正する。

## 問題

`try/finally` が `yield` 後にしか掛からない構造だったため、
`with temp:` 内の書き込みで例外が起きると `delete=False` の一時ファイルが残ってしまっていた。

## 修正

`try/finally` を `NamedTemporaryFile` 作成直後に移動し、書き込み失敗時もクリーンアップが確実に実行されるようにした。

## テスト

- `test_deletes_file_when_write_raises`: `write()` が OSError を投げた場合に一時ファイルが削除されることを確認するテストを追加

closes #65