### PR TITLE
AGENTS.md にCodexレビュー方針を追加する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# AGENTS.md
+
+## プロジェクト概要
+
+FFmpeg をラップしたシンプルな動画処理 CLI ツール。
+Python 製、外部ライブラリへの実行時依存なし。パッケージ管理は `uv`。
+
+## コマンド
+
+```bash
+# アプリ起動
+uv run python main.py
+
+# テスト実行
+uv run pytest
+
+# テスト（詳細表示）
+uv run pytest -v
+```
+
+## アーキテクチャ
+
+依存の向きは一方向のみ（上位が下位を参照し、逆方向は禁止）。
+
+```
+domain/        ← ドメインモデル（MediaInfo, TrimRange など）。外部依存なし
+ffmpeg/        ← FFmpeg/ffprobe ラッパー。domain を参照
+validation/    ← 入力バリデーション。domain を参照
+shared/        ← 共通ユーティリティ（errors, formatters）
+ui/            ← プロンプト・メニュー・レビュー画面
+usecases/      ← ユースケースフロー。ffmpeg/validation/ui を組み合わせる
+main.py        ← エントリーポイント・ディスパッチ
+```
+
+## Review guidelines
+
+- 依存方向がアーキテクチャのルールに違反していないか確認する。
+- 一時ファイル・外部プロセス・例外処理でリソースリークが起きないか重視する。
+- テストが問題の再発防止として具体的な失敗条件を固定できているか確認する。
+- UI（ask_* など）は mock し、ビジネスロジックを過剰に mock していないか確認する。
+- `uv run pytest` と lint/format の実行結果、または未実行理由を確認する。
+
+## 新機能追加の手順（厳守）
+
+**ファイルを変更する前に必ず issue を作ること。**
+
+```
+1. gh ic                          # issue 作成
+2. git checkout -b chore/N-説明   # N は issue 番号
+3. テストを書いて Red を確認
+4. 実装して Green にする
+5. gh pc でPR作成
+6. gh pr checks N --watch でCI確認
+7. gh pm N でマージ
+8. git checkout main && git pull
+```
+
+## 各機能の実装パターン
+
+新機能は必ず以下の4つをセットで実装する：
+
+| ファイル | 役割 |
+|---------|------|
+| `ffmpeg/commands.py` | `build_XXX_command()` 追加 |
+| `usecases/xxx_flow.py` | `XxxForm`, `run_xxx_flow()` など |
+| `tests/test_xxx_flow.py` | フローのテスト |
+| `tests/test_commands.py` | コマンド生成のテスト |
+
+さらに `domain/operations.py`・`ui/main_menu.py`・`main.py` の3箇所を更新する。
+
+## コミットメッセージのルール
+
+**Why（なぜそうしたのか）を日本語で書く。**  
+How（どう変えたか）はコードを見ればわかるので書かない。
+
+```
+変更の要約（1行）
+
+変更した理由・背景を説明する。
+何が問題で、なぜこの変更が必要だったのかを書く。
+
+Co-Authored-By: Codex Sonnet 4.6 <noreply@anthropic.com>
+```
+
+## コードコメントのルール
+
+コメントには **Why not** を書く（なぜ他の選択肢を選ばなかったか）。  
+What/How は書かない（コードを読めばわかる）。
+
+## テストのルール
+
+- TDD: Red → Green の順番を守る
+- UI（ask_* など）は mock する。ビジネスロジックは mock しない
+- `uv run pytest` が green の状態でのみリファクタリングする
+
+## gh コマンドのエイリアス
+
+| エイリアス | 説明 |
+|-----------|------|
+| `gh ic` | issue 作成 |
+| `gh pc` | PR 作成（main へ） |
+| `gh pm N` | PR マージ＆ブランチ削除 |
+| `gh il` | issue 一覧 |
+| `gh mypr` | 自分の PR 一覧 |


### PR DESCRIPTION
## 概要

Codex のGitHubレビューでリポジトリ固有の観点を参照できるように、AGENTS.md を追加する。

## 追加内容

- プロジェクト概要、コマンド、アーキテクチャ制約を記載
- Codex 向けの Review guidelines を追加
- 新機能追加、コミットメッセージ、コメント、テスト、gh alias の既存運用ルールを記載

## テスト

- ドキュメント追加のみのため未実行

closes #67