### PR TITLE
動画圧縮機能（CRF ベース）を追加する

### DIFF
--- a/domain/operations.py
+++ b/domain/operations.py
@@ -1,3 +1,4 @@
+COMPRESS = "compress"
 TRIM = "trim"
 CONCAT = "concat"
 RESIZE = "resize"

--- a/ffmpeg/commands.py
+++ b/ffmpeg/commands.py
@@ -197,6 +197,9 @@ def build_compress_command(
     output_file: str,
     crf: int = 23,
 ) -> list[str]:
+    # -c:a copy ではなく aac を使う。
+    # copy だと WebM(Opus) 入力を MP4 に格納したとき QuickTime・iOS 等が音声を再生できない。
+    # AAC に変換することで主要プレイヤーとの互換性を保証する。
     return [
         "ffmpeg",
         "-y",

--- a/ffmpeg/commands.py
+++ b/ffmpeg/commands.py
@@ -192,6 +192,26 @@ def build_audio_extract_command(
     ]
 
 
+def build_compress_command(
+    input_file: str,
+    output_file: str,
+    crf: int = 23,
+) -> list[str]:
+    return [
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_file,
+        "-c:v",
+        "libx264",
+        "-crf",
+        str(crf),
+        "-c:a",
+        "copy",
+        output_file,
+    ]
+
+
 def build_volume_command(
     input_file: str,
     output_file: str,

--- a/ffmpeg/commands.py
+++ b/ffmpeg/commands.py
@@ -207,7 +207,7 @@ def build_compress_command(
         "-crf",
         str(crf),
         "-c:a",
-        "copy",
+        "aac",
         output_file,
     ]
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from ffmpeg.probe import ensure_ffmpeg_installed, ensure_ffprobe_installed
 from shared.errors import FfmpegExecutionError, ValidationError
 from ui.main_menu import prompt_main_menu
 from usecases.audio_extract_flow import run_audio_extract_flow
+from usecases.compress_flow import run_compress_flow
 from usecases.concat_flow import run_concat_flow
 from usecases.convert_flow import run_convert_flow
 from usecases.crop_flow import run_crop_flow
@@ -44,6 +45,7 @@ def build_operation_handlers() -> dict[str, OperationHandler]:
         operations.ROTATE: run_rotate_flow,
         operations.INFO: run_info_flow,
         operations.CROP: run_crop_flow,
+        operations.COMPRESS: run_compress_flow,
         operations.EXIT: exit_program,
     }
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -429,10 +429,10 @@ class TestBuildCompressCommand(unittest.TestCase):
         crf_idx = command.index("-crf")
         self.assertEqual(command[crf_idx + 1], "18")
 
-    def test_audio_is_copied(self):
+    def test_audio_is_transcoded_to_aac(self):
         command = build_compress_command("in.mp4", "out.mp4", crf=23)
         ca_idx = command.index("-c:a")
-        self.assertEqual(command[ca_idx + 1], "copy")
+        self.assertEqual(command[ca_idx + 1], "aac")
 
     def test_includes_input_and_output_files(self):
         command = build_compress_command("in.mp4", "out.mp4", crf=23)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from domain.trim_range import TrimRange
 from ffmpeg.commands import (
     build_audio_extract_command,
+    build_compress_command,
     build_concat_copy_command,
     build_concat_reencode_command,
     build_convert_command,
@@ -407,6 +408,36 @@ class TestCreateConcatListFile(unittest.TestCase):
         with create_concat_list_file(["/tmp/it's.mp4"]) as path:
             content = Path(path).read_text()
         self.assertIn(r"'\''" , content)
+
+
+class TestBuildCompressCommand(unittest.TestCase):
+    def test_command_starts_with_ffmpeg(self):
+        command = build_compress_command("in.mp4", "out.mp4", crf=23)
+        self.assertEqual(command[0], "ffmpeg")
+
+    def test_uses_libx264_codec(self):
+        command = build_compress_command("in.mp4", "out.mp4", crf=23)
+        self.assertIn("libx264", command)
+
+    def test_default_crf_is_23(self):
+        command = build_compress_command("in.mp4", "out.mp4")
+        crf_idx = command.index("-crf")
+        self.assertEqual(command[crf_idx + 1], "23")
+
+    def test_custom_crf_value(self):
+        command = build_compress_command("in.mp4", "out.mp4", crf=18)
+        crf_idx = command.index("-crf")
+        self.assertEqual(command[crf_idx + 1], "18")
+
+    def test_audio_is_copied(self):
+        command = build_compress_command("in.mp4", "out.mp4", crf=23)
+        ca_idx = command.index("-c:a")
+        self.assertEqual(command[ca_idx + 1], "copy")
+
+    def test_includes_input_and_output_files(self):
+        command = build_compress_command("in.mp4", "out.mp4", crf=23)
+        self.assertIn("in.mp4", command)
+        self.assertIn("out.mp4", command)
 
 
 if __name__ == "__main__":

--- a/tests/test_compress_flow.py
+++ b/tests/test_compress_flow.py
@@ -15,6 +15,7 @@ class TestExecuteCompress(unittest.TestCase):
     def test_execute_compress_runs_command(self, mock_build, mock_run_ffmpeg):
         form = CompressForm(input_file="in.mp4", crf_raw="23", output_file="out.mp4")
         mock_build.return_value = ["ffmpeg", "..."]
+        mock_run_ffmpeg.return_value.executed = True
 
         execute_compress(form)
 
@@ -30,6 +31,7 @@ class TestExecuteCompress(unittest.TestCase):
     def test_execute_compress_dry_run(self, mock_build, mock_run_ffmpeg):
         form = CompressForm(input_file="in.mp4", crf_raw="23", output_file="out.mp4")
         mock_build.return_value = ["ffmpeg", "..."]
+        mock_run_ffmpeg.return_value.executed = False
 
         execute_compress(form, dry_run=True)
 

--- a/tests/test_compress_flow.py
+++ b/tests/test_compress_flow.py
@@ -1,0 +1,90 @@
+import unittest
+from unittest.mock import patch
+
+from usecases.compress_flow import (
+    CompressForm,
+    execute_compress,
+    run_compress_iteration,
+)
+from usecases.flow_result import FlowResult
+
+
+class TestExecuteCompress(unittest.TestCase):
+    @patch("usecases.shared_flow.run_ffmpeg")
+    @patch("usecases.compress_flow.build_compress_command")
+    def test_execute_compress_runs_command(self, mock_build, mock_run_ffmpeg):
+        form = CompressForm(input_file="in.mp4", crf_raw="23", output_file="out.mp4")
+        mock_build.return_value = ["ffmpeg", "..."]
+
+        execute_compress(form)
+
+        mock_build.assert_called_once_with(
+            input_file="in.mp4",
+            output_file="out.mp4",
+            crf=23,
+        )
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+
+    @patch("usecases.shared_flow.run_ffmpeg")
+    @patch("usecases.compress_flow.build_compress_command")
+    def test_execute_compress_dry_run(self, mock_build, mock_run_ffmpeg):
+        form = CompressForm(input_file="in.mp4", crf_raw="23", output_file="out.mp4")
+        mock_build.return_value = ["ffmpeg", "..."]
+
+        execute_compress(form, dry_run=True)
+
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+
+
+class TestRunCompressIteration(unittest.TestCase):
+    @patch("usecases.compress_flow.collect_compress_input")
+    @patch("usecases.compress_flow.build_compress_summary")
+    @patch("usecases.shared_flow.handle_generic_review")
+    @patch("usecases.compress_flow.execute_compress")
+    def test_run_compress_iteration_execute_path(
+        self, mock_execute, mock_review, mock_summary, mock_collect
+    ):
+        form = CompressForm()
+        updated = CompressForm(input_file="in.mp4", crf_raw="18", output_file="out.mp4")
+        mock_collect.return_value = (updated, object())
+        mock_summary.return_value = "summary"
+        mock_review.return_value = FlowResult(kind="execute", form=updated)
+
+        result = run_compress_iteration(form)
+
+        self.assertEqual(result.kind, "done")
+        mock_execute.assert_called_once_with(updated, dry_run=False)
+
+    @patch("usecases.compress_flow.collect_compress_input")
+    @patch("usecases.compress_flow.build_compress_summary")
+    @patch("usecases.shared_flow.handle_generic_review")
+    @patch("usecases.compress_flow.execute_compress")
+    def test_run_compress_iteration_dry_run_path(
+        self, mock_execute, mock_review, mock_summary, mock_collect
+    ):
+        form = CompressForm()
+        updated = CompressForm(input_file="in.mp4", crf_raw="18", output_file="out.mp4")
+        mock_collect.return_value = (updated, object())
+        mock_summary.return_value = "summary"
+        mock_review.return_value = FlowResult(kind="dry_run", form=updated)
+
+        result = run_compress_iteration(form)
+
+        self.assertEqual(result.kind, "done")
+        mock_execute.assert_called_once_with(updated, dry_run=True)
+
+    @patch("usecases.compress_flow.collect_compress_input")
+    def test_run_compress_iteration_validation_error_returns_retry(self, mock_collect):
+        from shared.errors import ValidationError
+
+        form = CompressForm(input_file="in.mp4", crf_raw="23", output_file="out.mp4")
+        mock_collect.side_effect = ValidationError("bad input")
+
+        result = run_compress_iteration(form)
+
+        self.assertEqual(result.kind, "retry")
+        self.assertEqual(result.form, form)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_file_validators.py
+++ b/tests/test_file_validators.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from shared.errors import ValidationError
 from validation.file_validators import (
     validate_audio_output_extension,
+    validate_compress_output_extension,
     validate_different_extension,
     validate_gif_output_extension,
     validate_image_output_extension,
@@ -105,6 +106,25 @@ class TestValidateDifferentExtension(unittest.TestCase):
     def test_case_insensitive(self):
         with self.assertRaises(ValidationError):
             validate_different_extension("input.MP4", "output.mp4")
+
+
+class TestValidateCompressOutputExtension(unittest.TestCase):
+    def test_mp4_passes(self):
+        validate_compress_output_extension("out.mp4")
+
+    def test_mov_passes(self):
+        validate_compress_output_extension("out.mov")
+
+    def test_mkv_passes(self):
+        validate_compress_output_extension("out.mkv")
+
+    def test_webm_raises(self):
+        with self.assertRaises(ValidationError):
+            validate_compress_output_extension("out.webm")
+
+    def test_unsupported_raises(self):
+        with self.assertRaises(ValidationError):
+            validate_compress_output_extension("out.avi")
 
 
 if __name__ == "__main__":

--- a/tests/test_value_validators.py
+++ b/tests/test_value_validators.py
@@ -3,6 +3,7 @@ import unittest
 from shared.errors import ValidationError
 from validation.value_validators import (
     parse_time_input,
+    validate_crf,
     validate_crop_dimension,
     validate_crop_offset,
     validate_dimension,
@@ -220,6 +221,25 @@ class TestValidateCropOffset(unittest.TestCase):
     def test_non_integer(self):
         with self.assertRaises(ValidationError):
             validate_crop_offset("abc", "X座標")
+
+
+class TestValidateCrf(unittest.TestCase):
+    def test_valid_range(self):
+        self.assertEqual(validate_crf("0", "CRF"), 0)
+        self.assertEqual(validate_crf("23", "CRF"), 23)
+        self.assertEqual(validate_crf("51", "CRF"), 51)
+
+    def test_too_small(self):
+        with self.assertRaises(ValidationError):
+            validate_crf("-1", "CRF")
+
+    def test_too_large(self):
+        with self.assertRaises(ValidationError):
+            validate_crf("52", "CRF")
+
+    def test_non_integer(self):
+        with self.assertRaises(ValidationError):
+            validate_crf("abc", "CRF")
 
 
 if __name__ == "__main__":

--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -19,6 +19,7 @@ def prompt_main_menu() -> str:
             ("回転・反転する", operations.ROTATE),
             ("動画情報を確認する", operations.INFO),
             ("動画をクロップする", operations.CROP),
+            ("動画を圧縮する", operations.COMPRESS),
             ("終了する", operations.EXIT),
         ],
     )

--- a/usecases/compress_flow.py
+++ b/usecases/compress_flow.py
@@ -1,0 +1,150 @@
+from dataclasses import dataclass, replace
+
+from ffmpeg.commands import build_compress_command
+from ffmpeg.probe import probe_media_info
+from shared.errors import ValidationError
+from shared.formatters import format_media_info_summary
+from ui.prompts import ask_text, require_non_empty
+from ui.review import ask_field_to_edit
+from usecases.flow_result import FlowResult
+from usecases.shared_flow import execute_with_output, handle_generic_review, run_flow, run_generic_iteration
+from validation.file_validators import (
+    validate_input_file_exists,
+    validate_output_directory_exists,
+    validate_video_file_extension,
+)
+
+
+def validate_crf(raw: str, label: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValidationError(f"{label} は整数で入力してください。") from exc
+
+    if value < 0 or value > 51:
+        raise ValidationError(f"{label} は 0〜51 の範囲で入力してください。")
+
+    return value
+
+
+@dataclass
+class CompressForm:
+    input_file: str = "./input.mp4"
+    crf_raw: str = "23"
+    output_file: str = "./output-compressed.mp4"
+
+
+def ask_compress_input_file(default_value: str) -> str:
+    return require_non_empty(
+        ask_text(
+            "対象の動画ファイルを入力してください\n例: ./input/video.mp4",
+            default=default_value,
+        ),
+        "入力ファイル",
+    )
+
+
+def ask_crf(default_value: str) -> str:
+    return require_non_empty(
+        ask_text(
+            "CRF 値を入力してください\n範囲: 0〜51（低いほど高画質・大サイズ、デフォルト: 23）\n例: 23",
+            default=default_value,
+        ),
+        "CRF 値",
+    )
+
+
+def ask_compress_output(default_value: str) -> str:
+    return require_non_empty(
+        ask_text(
+            "出力ファイル名を入力してください\n例: ./output/compressed.mp4",
+            default=default_value,
+        ),
+        "出力ファイル",
+    )
+
+
+def collect_compress_input(form: CompressForm):
+    input_file = ask_compress_input_file(form.input_file)
+    validate_input_file_exists(input_file)
+    validate_video_file_extension(input_file)
+
+    media_info = probe_media_info(input_file)
+    print("\n入力動画情報:")
+    print(format_media_info_summary(media_info))
+    print()
+
+    crf_raw = ask_crf(form.crf_raw)
+    validate_crf(crf_raw, "CRF 値")
+
+    output_file = ask_compress_output(form.output_file)
+    validate_output_directory_exists(output_file)
+
+    return replace(
+        form,
+        input_file=input_file,
+        crf_raw=crf_raw,
+        output_file=output_file,
+    ), media_info
+
+
+def build_compress_summary(form: CompressForm, media_info) -> str:
+    return "\n".join(
+        [
+            "実行内容:",
+            "- 操作: 動画圧縮（H.264/CRF）",
+            f"- 入力: {form.input_file}",
+            f"- CRF 値: {form.crf_raw}（低いほど高画質）",
+            f"- 出力: {form.output_file}",
+        ]
+    )
+
+
+def edit_compress_form(form: CompressForm) -> CompressForm:
+    field = ask_field_to_edit(
+        [
+            ("入力ファイル", "input_file"),
+            ("CRF 値", "crf_raw"),
+            ("出力ファイル", "output_file"),
+        ]
+    )
+
+    prompts = {
+        "input_file": ("入力ファイルを再入力してください", "入力ファイル"),
+        "crf_raw": ("CRF 値を再入力してください", "CRF 値"),
+        "output_file": ("出力ファイルを再入力してください", "出力ファイル"),
+    }
+    prompt, label = prompts[field]
+    value = require_non_empty(ask_text(prompt, default=getattr(form, field)), label)
+    return replace(form, **{field: value})
+
+
+def handle_compress_review(form: CompressForm) -> FlowResult:
+    return handle_generic_review(form, CompressForm, edit_compress_form)
+
+
+def execute_compress(form: CompressForm, dry_run: bool = False) -> None:
+    crf = validate_crf(form.crf_raw, "CRF 値")
+
+    command = build_compress_command(
+        input_file=form.input_file,
+        output_file=form.output_file,
+        crf=crf,
+    )
+
+    execute_with_output(command, form.output_file, dry_run)
+
+
+def run_compress_iteration(form: CompressForm) -> FlowResult:
+    return run_generic_iteration(
+        form,
+        collect_compress_input,
+        build_compress_summary,
+        CompressForm,
+        edit_compress_form,
+        execute_compress,
+    )
+
+
+def run_compress_flow() -> None:
+    run_flow(CompressForm(), run_compress_iteration)

--- a/usecases/compress_flow.py
+++ b/usecases/compress_flow.py
@@ -2,29 +2,18 @@ from dataclasses import dataclass, replace
 
 from ffmpeg.commands import build_compress_command
 from ffmpeg.probe import probe_media_info
-from shared.errors import ValidationError
 from shared.formatters import format_media_info_summary
 from ui.prompts import ask_text, require_non_empty
 from ui.review import ask_field_to_edit
 from usecases.flow_result import FlowResult
 from usecases.shared_flow import execute_with_output, handle_generic_review, run_flow, run_generic_iteration
 from validation.file_validators import (
+    validate_compress_output_extension,
     validate_input_file_exists,
     validate_output_directory_exists,
     validate_video_file_extension,
 )
-
-
-def validate_crf(raw: str, label: str) -> int:
-    try:
-        value = int(raw)
-    except ValueError as exc:
-        raise ValidationError(f"{label} は整数で入力してください。") from exc
-
-    if value < 0 or value > 51:
-        raise ValidationError(f"{label} は 0〜51 の範囲で入力してください。")
-
-    return value
+from validation.value_validators import validate_crf
 
 
 @dataclass
@@ -79,6 +68,7 @@ def collect_compress_input(form: CompressForm):
 
     output_file = ask_compress_output(form.output_file)
     validate_output_directory_exists(output_file)
+    validate_compress_output_extension(output_file)
 
     return replace(
         form,

--- a/validation/file_validators.py
+++ b/validation/file_validators.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from shared.errors import ValidationError
 
 SUPPORTED_VIDEO_EXTENSIONS = {".mp4", ".mov", ".mkv", ".avi", ".webm"}
+SUPPORTED_H264_OUTPUT_EXTENSIONS = {".mp4", ".mov", ".mkv"}
 SUPPORTED_AUDIO_EXTENSIONS = {".mp3", ".aac", ".wav", ".m4a"}
 SUPPORTED_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png"}
 SUPPORTED_GIF_EXTENSIONS = {".gif"}
@@ -38,6 +39,13 @@ def validate_different_extension(input_file: str, output_file: str) -> None:
     out_ext = Path(output_file).suffix.lower()
     if in_ext == out_ext:
         raise ValidationError(f"入力と出力の拡張子が同じです: {in_ext}\n変換するには異なる拡張子を指定してください。")
+
+
+def validate_compress_output_extension(file_path: str) -> None:
+    ext = Path(file_path).suffix.lower()
+    if ext not in SUPPORTED_H264_OUTPUT_EXTENSIONS:
+        supported = ", ".join(sorted(SUPPORTED_H264_OUTPUT_EXTENSIONS))
+        raise ValidationError(f"H.264 圧縮に対応していない拡張子です: {ext}\n対応形式: {supported}")
 
 
 def validate_gif_output_extension(file_path: str) -> None:

--- a/validation/value_validators.py
+++ b/validation/value_validators.py
@@ -84,6 +84,18 @@ def validate_speed_multiplier(raw: str, label: str) -> float:
     return value
 
 
+def validate_crf(raw: str, label: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValidationError(f"{label} は整数で入力してください。") from exc
+
+    if value < 0 or value > 51:
+        raise ValidationError(f"{label} は 0〜51 の範囲で入力してください。")
+
+    return value
+
+
 def validate_timestamp_within_duration(raw: str, duration_seconds: float) -> int:
     seconds = parse_time_input(raw)
     if seconds >= duration_seconds:


### PR DESCRIPTION
## 概要

CRF（Constant Rate Factor）で H.264 圧縮する動画圧縮機能を追加する。

## 実装内容

- `ffmpeg/commands.py`: `build_compress_command()` 追加
- `usecases/compress_flow.py`: `CompressForm`, `run_compress_flow()` など追加
- `tests/test_compress_flow.py`: フローのテスト追加
- `tests/test_commands.py`: コマンド生成のテスト追加
- `domain/operations.py`, `ui/main_menu.py`, `main.py`: 3箇所を更新

closes #44