### PR TITLE
フレームレート変換機能を追加する

### DIFF
--- a/domain/operations.py
+++ b/domain/operations.py
@@ -1,4 +1,5 @@
 COMPRESS = "compress"
+FPS = "fps"
 TRIM = "trim"
 CONCAT = "concat"
 RESIZE = "resize"

--- a/ffmpeg/commands.py
+++ b/ffmpeg/commands.py
@@ -215,6 +215,28 @@ def build_compress_command(
     ]
 
 
+def build_fps_command(
+    input_file: str,
+    output_file: str,
+    fps: float,
+) -> list[str]:
+    # -c:a aac ではなく copy を使う。
+    # fps 変換は映像フィルタのみ適用し、音声を変更する理由がない。
+    # copy にすることで音質劣化なし・エンコード時間の短縮・コーデック互換性の維持ができる。
+    fps_str = f"{fps:g}"
+    return [
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_file,
+        "-vf",
+        f"fps={fps_str}",
+        "-c:a",
+        "copy",
+        output_file,
+    ]
+
+
 def build_volume_command(
     input_file: str,
     output_file: str,

--- a/main.py
+++ b/main.py
@@ -6,10 +6,10 @@ from shared.errors import FfmpegExecutionError, ValidationError
 from ui.main_menu import prompt_main_menu
 from usecases.audio_extract_flow import run_audio_extract_flow
 from usecases.compress_flow import run_compress_flow
-from usecases.fps_flow import run_fps_flow
 from usecases.concat_flow import run_concat_flow
 from usecases.convert_flow import run_convert_flow
 from usecases.crop_flow import run_crop_flow
+from usecases.fps_flow import run_fps_flow
 from usecases.gif_flow import run_gif_flow
 from usecases.info_flow import run_info_flow
 from usecases.mute_flow import run_mute_flow

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from shared.errors import FfmpegExecutionError, ValidationError
 from ui.main_menu import prompt_main_menu
 from usecases.audio_extract_flow import run_audio_extract_flow
 from usecases.compress_flow import run_compress_flow
+from usecases.fps_flow import run_fps_flow
 from usecases.concat_flow import run_concat_flow
 from usecases.convert_flow import run_convert_flow
 from usecases.crop_flow import run_crop_flow
@@ -46,6 +47,7 @@ def build_operation_handlers() -> dict[str, OperationHandler]:
         operations.INFO: run_info_flow,
         operations.CROP: run_crop_flow,
         operations.COMPRESS: run_compress_flow,
+        operations.FPS: run_fps_flow,
         operations.EXIT: exit_program,
     }
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,6 +9,7 @@ from ffmpeg.commands import (
     build_concat_reencode_command,
     build_convert_command,
     build_crop_command,
+    build_fps_command,
     build_gif_command,
     build_mute_command,
     build_resize_command,
@@ -438,6 +439,20 @@ class TestBuildCompressCommand(unittest.TestCase):
         command = build_compress_command("in.mp4", "out.mp4", crf=23)
         self.assertIn("in.mp4", command)
         self.assertIn("out.mp4", command)
+
+
+class TestBuildFpsCommand(unittest.TestCase):
+    def test_basic(self):
+        command = build_fps_command("in.mp4", "out.mp4", fps=30.0)
+        self.assertEqual(
+            command,
+            ["ffmpeg", "-y", "-i", "in.mp4", "-vf", "fps=30", "-c:a", "copy", "out.mp4"],
+        )
+
+    def test_decimal_fps(self):
+        command = build_fps_command("in.mp4", "out.mp4", fps=23.976)
+        vf_idx = command.index("-vf")
+        self.assertEqual(command[vf_idx + 1], "fps=23.976")
 
 
 if __name__ == "__main__":

--- a/tests/test_fps_flow.py
+++ b/tests/test_fps_flow.py
@@ -1,0 +1,92 @@
+import unittest
+from unittest.mock import patch
+
+from usecases.fps_flow import (
+    FpsForm,
+    execute_fps,
+    run_fps_iteration,
+)
+from usecases.flow_result import FlowResult
+
+
+class TestExecuteFps(unittest.TestCase):
+    @patch("usecases.shared_flow.run_ffmpeg")
+    @patch("usecases.fps_flow.build_fps_command")
+    def test_execute_fps_runs_command(self, mock_build, mock_run_ffmpeg):
+        form = FpsForm(input_file="in.mp4", fps_raw="30", output_file="out.mp4")
+        mock_build.return_value = ["ffmpeg", "..."]
+        mock_run_ffmpeg.return_value.executed = True
+
+        execute_fps(form)
+
+        mock_build.assert_called_once_with(
+            input_file="in.mp4",
+            output_file="out.mp4",
+            fps=30.0,
+        )
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+
+    @patch("usecases.shared_flow.run_ffmpeg")
+    @patch("usecases.fps_flow.build_fps_command")
+    def test_execute_fps_dry_run(self, mock_build, mock_run_ffmpeg):
+        form = FpsForm(input_file="in.mp4", fps_raw="30", output_file="out.mp4")
+        mock_build.return_value = ["ffmpeg", "..."]
+        mock_run_ffmpeg.return_value.executed = False
+
+        execute_fps(form, dry_run=True)
+
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+
+
+class TestRunFpsIteration(unittest.TestCase):
+    @patch("usecases.fps_flow.collect_fps_input")
+    @patch("usecases.fps_flow.build_fps_summary")
+    @patch("usecases.shared_flow.handle_generic_review")
+    @patch("usecases.fps_flow.execute_fps")
+    def test_run_fps_iteration_execute_path(
+        self, mock_execute, mock_review, mock_summary, mock_collect
+    ):
+        form = FpsForm()
+        updated = FpsForm(input_file="in.mp4", fps_raw="30", output_file="out.mp4")
+        mock_collect.return_value = (updated, object())
+        mock_summary.return_value = "summary"
+        mock_review.return_value = FlowResult(kind="execute", form=updated)
+
+        result = run_fps_iteration(form)
+
+        self.assertEqual(result.kind, "done")
+        mock_execute.assert_called_once_with(updated, dry_run=False)
+
+    @patch("usecases.fps_flow.collect_fps_input")
+    @patch("usecases.fps_flow.build_fps_summary")
+    @patch("usecases.shared_flow.handle_generic_review")
+    @patch("usecases.fps_flow.execute_fps")
+    def test_run_fps_iteration_dry_run_path(
+        self, mock_execute, mock_review, mock_summary, mock_collect
+    ):
+        form = FpsForm()
+        updated = FpsForm(input_file="in.mp4", fps_raw="30", output_file="out.mp4")
+        mock_collect.return_value = (updated, object())
+        mock_summary.return_value = "summary"
+        mock_review.return_value = FlowResult(kind="dry_run", form=updated)
+
+        result = run_fps_iteration(form)
+
+        self.assertEqual(result.kind, "done")
+        mock_execute.assert_called_once_with(updated, dry_run=True)
+
+    @patch("usecases.fps_flow.collect_fps_input")
+    def test_run_fps_iteration_validation_error_returns_retry(self, mock_collect):
+        from shared.errors import ValidationError
+
+        form = FpsForm(input_file="in.mp4", fps_raw="30", output_file="out.mp4")
+        mock_collect.side_effect = ValidationError("bad input")
+
+        result = run_fps_iteration(form)
+
+        self.assertEqual(result.kind, "retry")
+        self.assertEqual(result.form, form)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fps_flow.py
+++ b/tests/test_fps_flow.py
@@ -1,12 +1,12 @@
 import unittest
 from unittest.mock import patch
 
+from usecases.flow_result import FlowResult
 from usecases.fps_flow import (
     FpsForm,
     execute_fps,
     run_fps_iteration,
 )
-from usecases.flow_result import FlowResult
 
 
 class TestExecuteFps(unittest.TestCase):

--- a/tests/test_value_validators.py
+++ b/tests/test_value_validators.py
@@ -8,6 +8,7 @@ from validation.value_validators import (
     validate_crop_offset,
     validate_dimension,
     validate_fps,
+    validate_fps_rate,
     validate_gif_width,
     validate_speed_multiplier,
     validate_timestamp_within_duration,
@@ -240,6 +241,32 @@ class TestValidateCrf(unittest.TestCase):
     def test_non_integer(self):
         with self.assertRaises(ValidationError):
             validate_crf("abc", "CRF")
+
+
+class TestValidateFpsRate(unittest.TestCase):
+    def test_valid_integer(self):
+        self.assertEqual(validate_fps_rate("30", "fps"), 30.0)
+
+    def test_valid_decimal(self):
+        self.assertAlmostEqual(validate_fps_rate("23.976", "fps"), 23.976)
+
+    def test_lower_bound(self):
+        self.assertEqual(validate_fps_rate("1", "fps"), 1.0)
+
+    def test_upper_bound(self):
+        self.assertEqual(validate_fps_rate("120", "fps"), 120.0)
+
+    def test_below_lower_bound(self):
+        with self.assertRaises(ValidationError):
+            validate_fps_rate("0", "fps")
+
+    def test_above_upper_bound(self):
+        with self.assertRaises(ValidationError):
+            validate_fps_rate("121", "fps")
+
+    def test_non_numeric(self):
+        with self.assertRaises(ValidationError):
+            validate_fps_rate("abc", "fps")
 
 
 if __name__ == "__main__":

--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -20,6 +20,7 @@ def prompt_main_menu() -> str:
             ("動画情報を確認する", operations.INFO),
             ("動画をクロップする", operations.CROP),
             ("動画を圧縮する", operations.COMPRESS),
+            ("フレームレートを変換する", operations.FPS),
             ("終了する", operations.EXIT),
         ],
     )

--- a/usecases/fps_flow.py
+++ b/usecases/fps_flow.py
@@ -1,0 +1,134 @@
+from dataclasses import dataclass, replace
+
+from ffmpeg.commands import build_fps_command
+from ffmpeg.probe import probe_media_info
+from shared.formatters import format_media_info_summary
+from ui.prompts import ask_text, require_non_empty
+from ui.review import ask_field_to_edit
+from usecases.flow_result import FlowResult
+from usecases.shared_flow import execute_with_output, handle_generic_review, run_flow, run_generic_iteration
+from validation.file_validators import (
+    validate_input_file_exists,
+    validate_output_directory_exists,
+    validate_video_file_extension,
+)
+from validation.value_validators import validate_fps_rate
+
+
+@dataclass
+class FpsForm:
+    input_file: str = "./input.mp4"
+    fps_raw: str = "30"
+    output_file: str = "./output-fps.mp4"
+
+
+def ask_fps_input_file(default_value: str) -> str:
+    return require_non_empty(
+        ask_text(
+            "対象の動画ファイルを入力してください\n例: ./input/video.mp4",
+            default=default_value,
+        ),
+        "入力ファイル",
+    )
+
+
+def ask_fps(default_value: str) -> str:
+    return require_non_empty(
+        ask_text(
+            "フレームレートを入力してください\n範囲: 1〜120（小数対応、例: 23.976）\n例: 30",
+            default=default_value,
+        ),
+        "フレームレート",
+    )
+
+
+def ask_fps_output(default_value: str) -> str:
+    return require_non_empty(
+        ask_text(
+            "出力ファイル名を入力してください\n例: ./output/video-30fps.mp4",
+            default=default_value,
+        ),
+        "出力ファイル",
+    )
+
+
+def collect_fps_input(form: FpsForm):
+    input_file = ask_fps_input_file(form.input_file)
+    validate_input_file_exists(input_file)
+    validate_video_file_extension(input_file)
+
+    media_info = probe_media_info(input_file)
+    print("\n入力動画情報:")
+    print(format_media_info_summary(media_info))
+    print()
+
+    fps_raw = ask_fps(form.fps_raw)
+    validate_fps_rate(fps_raw, "フレームレート")
+
+    output_file = ask_fps_output(form.output_file)
+    validate_output_directory_exists(output_file)
+    validate_video_file_extension(output_file)
+
+    return replace(form, input_file=input_file, fps_raw=fps_raw, output_file=output_file), media_info
+
+
+def build_fps_summary(form: FpsForm, media_info) -> str:
+    return "\n".join(
+        [
+            "実行内容:",
+            "- 操作: フレームレート変換",
+            f"- 入力: {form.input_file}",
+            f"- フレームレート: {form.fps_raw} fps",
+            f"- 出力: {form.output_file}",
+        ]
+    )
+
+
+def edit_fps_form(form: FpsForm) -> FpsForm:
+    field = ask_field_to_edit(
+        [
+            ("入力ファイル", "input_file"),
+            ("フレームレート", "fps_raw"),
+            ("出力ファイル", "output_file"),
+        ]
+    )
+
+    prompts = {
+        "input_file": ("入力ファイルを再入力してください", "入力ファイル"),
+        "fps_raw": ("フレームレートを再入力してください", "フレームレート"),
+        "output_file": ("出力ファイルを再入力してください", "出力ファイル"),
+    }
+    prompt, label = prompts[field]
+    value = require_non_empty(ask_text(prompt, default=getattr(form, field)), label)
+    return replace(form, **{field: value})
+
+
+def handle_fps_review(form: FpsForm) -> FlowResult:
+    return handle_generic_review(form, FpsForm, edit_fps_form)
+
+
+def execute_fps(form: FpsForm, dry_run: bool = False) -> None:
+    fps = validate_fps_rate(form.fps_raw, "フレームレート")
+
+    command = build_fps_command(
+        input_file=form.input_file,
+        output_file=form.output_file,
+        fps=fps,
+    )
+
+    execute_with_output(command, form.output_file, dry_run)
+
+
+def run_fps_iteration(form: FpsForm) -> FlowResult:
+    return run_generic_iteration(
+        form,
+        collect_fps_input,
+        build_fps_summary,
+        FpsForm,
+        edit_fps_form,
+        execute_fps,
+    )
+
+
+def run_fps_flow() -> None:
+    run_flow(FpsForm(), run_fps_iteration)

--- a/validation/value_validators.py
+++ b/validation/value_validators.py
@@ -84,6 +84,18 @@ def validate_speed_multiplier(raw: str, label: str) -> float:
     return value
 
 
+def validate_fps_rate(raw: str, label: str) -> float:
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValidationError(f"{label} は数値で入力してください。") from exc
+
+    if value < 1 or value > 120:
+        raise ValidationError(f"{label} は 1〜120 の範囲で入力してください。")
+
+    return value
+
+
 def validate_crf(raw: str, label: str) -> int:
     try:
         value = int(raw)


### PR DESCRIPTION
closes #45

## 概要

動画のフレームレート（fps）を変換する機能を追加する。

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `ffmpeg/commands.py` | `build_fps_command()` 追加 |
| `usecases/fps_flow.py` | `FpsForm`, `run_fps_flow()` など新規追加 |
| `tests/test_fps_flow.py` | フローのテスト新規追加 |
| `tests/test_commands.py` | `TestBuildFpsCommand` 追加 |
| `tests/test_value_validators.py` | `TestValidateFpsRate` 追加 |
| `validation/value_validators.py` | `validate_fps_rate()` 追加（1〜120、小数対応） |
| `domain/operations.py` | `FPS = "fps"` 追加 |
| `ui/main_menu.py` | 「フレームレートを変換する」メニュー追加 |
| `main.py` | `operations.FPS` → `run_fps_flow` ルーティング追加 |

## 設計上の判断

- 音声は `-c:a copy`（再エンコードなし）。fps 変換は映像フィルタのみ適用し、音声を変更する理由がない。copy にすることで音質劣化なし・高速・コーデック互換性を維持できる。
- fps の範囲を 1〜120（小数対応）とした。既存の `validate_fps`（GIF 用、1〜60 整数）とは別に `validate_fps_rate` として追加。
- 整数 fps（30.0）をコマンドに渡す際は `g` フォーマット（`"30"`）で末尾の `.0` を除去する。