### PR TITLE
fix: WebM音声コーデック不整合とNaN fps入力未検出を修正する

### DIFF
--- a/ffmpeg/commands.py
+++ b/ffmpeg/commands.py
@@ -220,9 +220,9 @@ def build_fps_command(
     output_file: str,
     fps: float,
 ) -> list[str]:
-    # -c:a aac ではなく copy を使う。
-    # fps 変換は映像フィルタのみ適用し、音声を変更する理由がない。
-    # copy にすることで音質劣化なし・エンコード時間の短縮・コーデック互換性の維持ができる。
+    # copy を基本とするが WebM は AAC 非対応のため libopus を使う。
+    # WebM の仕様上、音声は Vorbis/Opus のみ許容される。copy では muxer エラーになる。
+    audio_codec = "libopus" if output_file.lower().endswith(".webm") else "copy"
     fps_str = f"{fps:g}"
     return [
         "ffmpeg",
@@ -232,7 +232,7 @@ def build_fps_command(
         "-vf",
         f"fps={fps_str}",
         "-c:a",
-        "copy",
+        audio_codec,
         output_file,
     ]
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -454,6 +454,16 @@ class TestBuildFpsCommand(unittest.TestCase):
         vf_idx = command.index("-vf")
         self.assertEqual(command[vf_idx + 1], "fps=23.976")
 
+    def test_webm_output_uses_libopus(self):
+        command = build_fps_command("in.mp4", "out.webm", fps=30.0)
+        ca_idx = command.index("-c:a")
+        self.assertEqual(command[ca_idx + 1], "libopus")
+
+    def test_mp4_output_uses_copy(self):
+        command = build_fps_command("in.mp4", "out.mp4", fps=30.0)
+        ca_idx = command.index("-c:a")
+        self.assertEqual(command[ca_idx + 1], "copy")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_value_validators.py
+++ b/tests/test_value_validators.py
@@ -131,6 +131,10 @@ class TestValidateSpeedMultiplier(unittest.TestCase):
     def test_one_is_valid(self):
         self.assertAlmostEqual(validate_speed_multiplier("1.0", "速度"), 1.0)
 
+    def test_nan_raises_error(self):
+        with self.assertRaises(ValidationError):
+            validate_speed_multiplier("nan", "速度")
+
 
 class TestValidateTimestampWithinDuration(unittest.TestCase):
     def test_valid_seconds(self):
@@ -179,6 +183,10 @@ class TestValidateVolumeLevel(unittest.TestCase):
     def test_too_large(self):
         with self.assertRaises(ValidationError):
             validate_volume_level("10.1", "音量")
+
+    def test_nan_raises_error(self):
+        with self.assertRaises(ValidationError):
+            validate_volume_level("nan", "音量")
 
 
 class TestValidateCropDimension(unittest.TestCase):
@@ -267,6 +275,14 @@ class TestValidateFpsRate(unittest.TestCase):
     def test_non_numeric(self):
         with self.assertRaises(ValidationError):
             validate_fps_rate("abc", "fps")
+
+    def test_nan_raises_error(self):
+        with self.assertRaises(ValidationError):
+            validate_fps_rate("nan", "fps")
+
+    def test_inf_raises_error(self):
+        with self.assertRaises(ValidationError):
+            validate_fps_rate("inf", "fps")
 
 
 if __name__ == "__main__":

--- a/validation/value_validators.py
+++ b/validation/value_validators.py
@@ -1,7 +1,14 @@
+import math
 import re
 
 from domain.trim_range import TrimRange
 from shared.errors import ValidationError
+
+
+def require_non_empty(value: str, field_name: str) -> str:
+    if value.strip() == "":
+        raise ValidationError(f"{field_name}は空にできません。")
+    return value
 
 
 def parse_hhmmss_groups(groups: tuple[str, str, str]) -> tuple[int, int, int]:
@@ -78,7 +85,7 @@ def validate_speed_multiplier(raw: str, label: str) -> float:
     except ValueError as exc:
         raise ValidationError(f"{label} は数値で入力してください。") from exc
 
-    if value < 0.25 or value > 4.0:
+    if not math.isfinite(value) or value < 0.25 or value > 4.0:
         raise ValidationError(f"{label} は 0.25〜4.0 の範囲で入力してください。")
 
     return value
@@ -90,7 +97,7 @@ def validate_fps_rate(raw: str, label: str) -> float:
     except ValueError as exc:
         raise ValidationError(f"{label} は数値で入力してください。") from exc
 
-    if value < 1 or value > 120:
+    if not math.isfinite(value) or value < 1 or value > 120:
         raise ValidationError(f"{label} は 1〜120 の範囲で入力してください。")
 
     return value

--- a/validation/value_validators.py
+++ b/validation/value_validators.py
@@ -152,7 +152,7 @@ def validate_volume_level(raw: str, label: str) -> float:
     except ValueError as exc:
         raise ValidationError(f"{label} は数値で入力してください。") from exc
 
-    if value < 0.0 or value > 10.0:
+    if not math.isfinite(value) or value < 0.0 or value > 10.0:
         raise ValidationError(f"{label} は 0.0〜10.0 の範囲で入力してください。")
 
     return value


### PR DESCRIPTION
## 概要

PR #71 のフレームレート変換機能に対して Codex が指摘した P2 不具合 2 件を修正します。

closes #72

## 修正内容

### 1. WebM 出力時の音声コーデック不整合（`ffmpeg/commands.py`）

`build_fps_command` が出力形式に関わらず `-c:a copy` を使っていたため、
WebM 出力時に FFmpeg の muxer エラーになっていた。
WebM コンテナは AAC 非対応（Vorbis/Opus のみ許容）のため、
`.webm` 拡張子の場合は `libopus` を選択するよう修正。

### 2. NaN / Inf の fps 入力が検出されない（`validation/value_validators.py`）

`float("nan")` / `float("inf")` は `ValueError` を投げないため
`try/except` では捕捉できず、後続の範囲チェック（`< 1 or > 120`）も
NaN との比較が常に `False` を返すため素通りしていた。
`math.isfinite()` で明示的に弾くよう修正。

## テスト

- `test_webm_output_uses_libopus` / `test_mp4_output_uses_copy` を追加
- `test_nan_raises_error` / `test_inf_raises_error` を追加