### PR TITLE
fix: edit_crop_form の再入力ラベルを日本語化しコメントを修正する

### DIFF
--- a/tests/test_crop_flow.py
+++ b/tests/test_crop_flow.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 from usecases.crop_flow import (
     CropForm,
+    edit_crop_form,
     execute_crop,
     handle_crop_review,
     run_crop_iteration,
@@ -98,6 +99,34 @@ class TestRunCropIteration(unittest.TestCase):
         result = run_crop_iteration(form, ui)
         self.assertEqual(result.kind, "retry")
         self.assertEqual(result.form, form)
+
+
+class TestEditCropForm(unittest.TestCase):
+    def _make_ui(self, field_choice, text_return="100"):
+        ui = Mock()
+        ui.ask_menu.return_value = field_choice
+        ui.ask_text.return_value = text_return
+        return ui
+
+    def test_width_prompt_uses_japanese_label(self):
+        ui = self._make_ui("width")
+        edit_crop_form(CropForm(width=640), ui)
+        ui.ask_text.assert_called_once_with("幅 を再入力してください", default="640")
+
+    def test_height_prompt_uses_japanese_label(self):
+        ui = self._make_ui("height")
+        edit_crop_form(CropForm(height=360), ui)
+        ui.ask_text.assert_called_once_with("高さ を再入力してください", default="360")
+
+    def test_x_prompt_uses_japanese_label(self):
+        ui = self._make_ui("x")
+        edit_crop_form(CropForm(x=0), ui)
+        ui.ask_text.assert_called_once_with("X座標 を再入力してください", default="0")
+
+    def test_y_prompt_uses_japanese_label(self):
+        ui = self._make_ui("y")
+        edit_crop_form(CropForm(y=0), ui)
+        ui.ask_text.assert_called_once_with("Y座標 を再入力してください", default="0")
 
 
 if __name__ == "__main__":

--- a/tests/test_main_dispatch.py
+++ b/tests/test_main_dispatch.py
@@ -52,7 +52,7 @@ class TestBuildOperationHandlers(unittest.TestCase):
                 return choices[0][1] if choices else ""
 
         stub = StubUI()
-        # CliUI 固有の型しか受け入れない実装だと、ここで TypeError が上がる
+        # CliUI 固有の型しか受け入れない実装だと、静的型チェッカーがここでエラーを報告する
         handlers = build_operation_handlers(stub)
         self.assertIn("trim", handlers)
         self.assertIn("fps", handlers)

--- a/usecases/crop_flow.py
+++ b/usecases/crop_flow.py
@@ -13,6 +13,15 @@ from validation.file_validators import (
 )
 from validation.value_validators import require_non_empty, validate_crop_dimension, validate_crop_offset
 
+_FIELD_LABELS: dict[str, str] = {
+    "width": "幅",
+    "height": "高さ",
+    "x": "X座標",
+    "y": "Y座標",
+    "input_file": "入力ファイル",
+    "output_file": "出力ファイル",
+}
+
 
 @dataclass
 class CropForm:
@@ -86,17 +95,17 @@ def edit_crop_form(form: CropForm, ui: UIPort) -> CropForm:
             ("出力ファイル", "output_file"),
         ],
     )
+    label = _FIELD_LABELS[field]
     if field in ("width", "height"):
-        raw = ui.ask_text(f"{field} を再入力してください", default=str(getattr(form, field)))
-        value = validate_crop_dimension(raw, field)
+        raw = ui.ask_text(f"{label} を再入力してください", default=str(getattr(form, field)))
+        value = validate_crop_dimension(raw, label)
     elif field in ("x", "y"):
-        raw = ui.ask_text(f"{field} を再入力してください", default=str(getattr(form, field)))
-        value = validate_crop_offset(raw, field)
+        raw = ui.ask_text(f"{label} を再入力してください", default=str(getattr(form, field)))
+        value = validate_crop_offset(raw, label)
     else:
-        labels = {"input_file": "入力ファイル", "output_file": "出力ファイル"}
         value = require_non_empty(
-            ui.ask_text(f"{labels[field]} を再入力してください", default=getattr(form, field)),
-            labels[field],
+            ui.ask_text(f"{label} を再入力してください", default=getattr(form, field)),
+            label,
         )
     return replace(form, **{field: value})
 


### PR DESCRIPTION
## 概要

PR #75 で残っていた Copilot レビュー 2 件を対応。

## 変更内容

### 1. `usecases/crop_flow.py` — 内部キーを日本語ラベルに統一

`edit_crop_form` が `"width"` / `"height"` / `"x"` / `"y"` という内部キーを
ユーザー向けプロンプトとバリデーションラベルに渡していた。
`_FIELD_LABELS` マップを導入し、日本語ラベルに統一した。

### 2. `tests/test_main_dispatch.py` — コメントを正確な表現に修正

「ここで TypeError が上がる」→「静的型チェッカーがここでエラーを報告する」

## TDD

Red（4 件失敗確認）→ Green（修正後全件通過）

closes #78