### PR TITLE
feat: FFmpeg の処理進捗をプログレスバーで表示する

### DIFF
--- a/ffmpeg/runner.py
+++ b/ffmpeg/runner.py
@@ -1,8 +1,18 @@
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from shared.command_formatter import format_command
 from shared.errors import FfmpegExecutionError
+
+
+@dataclass(frozen=True)
+class ProgressInfo:
+    frame: int = 0
+    speed: str = ""
+    # out_time_ms ではなく out_time（文字列）を使う。
+    # FFmpeg の out_time_ms はフィールド名に反してマイクロ秒単位であり混乱を招くため。
+    out_time: str = ""
 
 
 @dataclass(frozen=True)
@@ -11,17 +21,62 @@ class RunResult:
     command: list[str]
 
 
-def run_ffmpeg(command: list[str], dry_run: bool = False) -> RunResult:
+def parse_progress_chunk(lines: list[str]) -> ProgressInfo:
+    kv: dict[str, str] = {}
+    for line in lines:
+        if "=" in line:
+            key, _, value = line.partition("=")
+            kv[key] = value
+    return ProgressInfo(
+        frame=int(kv["frame"]) if "frame" in kv else 0,
+        speed=kv.get("speed", ""),
+        out_time=kv.get("out_time", "")[:8] if "out_time" in kv else "",
+    )
+
+
+def run_ffmpeg(
+    command: list[str],
+    dry_run: bool = False,
+    progress_callback: Callable[[ProgressInfo], None] | None = None,
+) -> RunResult:
     if dry_run:
         return RunResult(executed=False, command=command)
 
-    try:
-        subprocess.run(command, check=True)
-    except subprocess.CalledProcessError as exc:
-        detail = f"終了コード: {exc.returncode}\n実行コマンド: {format_command(command)}"
-        raise FfmpegExecutionError(
-            "FFmpeg の実行に失敗しました。",
-            detail=detail,
-        ) from exc
+    if progress_callback is None:
+        try:
+            subprocess.run(command, check=True)
+        except subprocess.CalledProcessError as exc:
+            detail = f"終了コード: {exc.returncode}\n実行コマンド: {format_command(command)}"
+            raise FfmpegExecutionError("FFmpeg の実行に失敗しました。", detail=detail) from exc
+        return RunResult(executed=True, command=command)
 
+    return _run_ffmpeg_with_progress(command, progress_callback)
+
+
+def _run_ffmpeg_with_progress(
+    command: list[str],
+    progress_callback: Callable[[ProgressInfo], None],
+) -> RunResult:
+    cmd = command[:1] + ["-progress", "pipe:1"] + command[1:]
+    chunk: list[str] = []
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        # stderr をキャプチャして非ゼロ終了時の detail に使う。
+        # DEVNULL だとエラー原因が隠れるため。
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdout is not None
+    for raw_line in proc.stdout:
+        line = raw_line.rstrip()
+        chunk.append(line)
+        if line.startswith("progress="):
+            progress_callback(parse_progress_chunk(chunk))
+            chunk = []
+    proc.wait()
+    if proc.returncode != 0:
+        stderr_text = proc.stderr.read() if proc.stderr else ""
+        detail = f"終了コード: {proc.returncode}\n{stderr_text}\n実行コマンド: {format_command(cmd)}"
+        raise FfmpegExecutionError("FFmpeg の実行に失敗しました。", detail=detail)
     return RunResult(executed=True, command=command)

--- a/tests/test_audio_extract_flow.py
+++ b/tests/test_audio_extract_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.audio_extract_flow import (
     AudioExtractForm,
@@ -64,7 +64,7 @@ class TestExecuteAudioExtract(unittest.TestCase):
         mock_build.return_value = ["ffmpeg", "..."]
         execute_audio_extract(form)
         mock_build.assert_called_once_with(input_file="in.mp4", output_file="out.mp3")
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.audio_extract_flow.build_audio_extract_command")
@@ -72,7 +72,7 @@ class TestExecuteAudioExtract(unittest.TestCase):
         form = AudioExtractForm(input_file="in.mp4", output_file="out.mp3")
         mock_build.return_value = ["ffmpeg", "..."]
         execute_audio_extract(form, dry_run=True)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunAudioExtractIteration(unittest.TestCase):

--- a/tests/test_compress_flow.py
+++ b/tests/test_compress_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.compress_flow import (
     CompressForm,
@@ -24,7 +24,7 @@ class TestExecuteCompress(unittest.TestCase):
             output_file="out.mp4",
             crf=23,
         )
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.compress_flow.build_compress_command")
@@ -35,7 +35,7 @@ class TestExecuteCompress(unittest.TestCase):
 
         execute_compress(form, dry_run=True)
 
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunCompressIteration(unittest.TestCase):

--- a/tests/test_concat_flow.py
+++ b/tests/test_concat_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 from usecases.concat_flow import (
     ConcatForm,
@@ -41,7 +41,7 @@ class TestExecuteConcat(unittest.TestCase):
         mock_create_concat_list_file.assert_called_once_with(["a.mp4", "b.mp4"])
         mock_choose_concat_strategy.assert_called_once_with(True)
         strategy.build.assert_called_once_with("/tmp/list.txt", "out.mp4")
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.concat_flow.choose_concat_strategy")
@@ -74,7 +74,7 @@ class TestExecuteConcat(unittest.TestCase):
         mock_create_concat_list_file.assert_called_once_with(["a.mp4", "b.mp4"])
         mock_choose_concat_strategy.assert_called_once_with(True)
         strategy.build.assert_called_once_with("/tmp/list.txt", "out.mp4")
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.concat_flow.choose_concat_strategy")

--- a/tests/test_convert_flow.py
+++ b/tests/test_convert_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.convert_flow import (
     ConvertForm,
@@ -61,7 +61,7 @@ class TestExecuteConvert(unittest.TestCase):
         mock_build.return_value = ["ffmpeg", "..."]
         execute_convert(form)
         mock_build.assert_called_once_with(input_file="in.mov", output_file="out.mp4")
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.convert_flow.build_convert_command")
@@ -69,7 +69,7 @@ class TestExecuteConvert(unittest.TestCase):
         form = ConvertForm(input_file="in.mov", output_file="out.mp4")
         mock_build.return_value = ["ffmpeg", "..."]
         execute_convert(form, dry_run=True)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunConvertIteration(unittest.TestCase):

--- a/tests/test_crop_flow.py
+++ b/tests/test_crop_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.crop_flow import (
     CropForm,
@@ -62,7 +62,7 @@ class TestExecuteCrop(unittest.TestCase):
         mock_build.return_value = ["ffmpeg", "..."]
         execute_crop(form)
         mock_build.assert_called_once_with(input_file="in.mp4", output_file="out.mp4", width=640, height=360, x=0, y=0)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.crop_flow.build_crop_command")
@@ -70,7 +70,7 @@ class TestExecuteCrop(unittest.TestCase):
         form = CropForm(input_file="in.mp4", width=640, height=360, x=0, y=0, output_file="out.mp4")
         mock_build.return_value = ["ffmpeg", "..."]
         execute_crop(form, dry_run=True)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunCropIteration(unittest.TestCase):

--- a/tests/test_fps_flow.py
+++ b/tests/test_fps_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.flow_result import FlowResult
 from usecases.fps_flow import (
@@ -24,7 +24,7 @@ class TestExecuteFps(unittest.TestCase):
             output_file="out.mp4",
             fps=30.0,
         )
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.fps_flow.build_fps_command")
@@ -35,7 +35,7 @@ class TestExecuteFps(unittest.TestCase):
 
         execute_fps(form, dry_run=True)
 
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunFpsIteration(unittest.TestCase):

--- a/tests/test_gif_flow.py
+++ b/tests/test_gif_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.flow_result import FlowResult
 from usecases.gif_flow import (
@@ -64,7 +64,7 @@ class TestExecuteGif(unittest.TestCase):
         mock_build.return_value = ["ffmpeg", "..."]
         execute_gif(form)
         mock_build.assert_called_once_with(input_file="in.mp4", output_file="out.gif", fps=10, width=480)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.gif_flow.build_gif_command")
@@ -72,7 +72,7 @@ class TestExecuteGif(unittest.TestCase):
         form = GifForm(input_file="in.mp4", fps_raw="10", width_raw="480", output_file="out.gif")
         mock_build.return_value = ["ffmpeg", "..."]
         execute_gif(form, dry_run=True)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunGifIteration(unittest.TestCase):

--- a/tests/test_mute_flow.py
+++ b/tests/test_mute_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.flow_result import FlowResult
 from usecases.mute_flow import (
@@ -64,7 +64,7 @@ class TestExecuteMute(unittest.TestCase):
         mock_build.return_value = ["ffmpeg", "..."]
         execute_mute(form)
         mock_build.assert_called_once_with(input_file="in.mp4", output_file="out.mp4")
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.mute_flow.build_mute_command")
@@ -72,7 +72,7 @@ class TestExecuteMute(unittest.TestCase):
         form = MuteForm(input_file="in.mp4", output_file="out.mp4")
         mock_build.return_value = ["ffmpeg", "..."]
         execute_mute(form, dry_run=True)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunMuteIteration(unittest.TestCase):

--- a/tests/test_resize_flow.py
+++ b/tests/test_resize_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.flow_result import FlowResult
 from usecases.resize_flow import (
@@ -66,7 +66,7 @@ class TestExecuteResize(unittest.TestCase):
         mock_build_resize_command.assert_called_once_with(
             input_file="in.mp4", output_file="out.mp4", width=1280, height=720
         )
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.resize_flow.build_resize_command")
@@ -74,7 +74,7 @@ class TestExecuteResize(unittest.TestCase):
         form = ResizeForm(input_file="in.mp4", width_raw="1280", height_raw="720", output_file="out.mp4")
         mock_build_resize_command.return_value = ["ffmpeg", "..."]
         execute_resize(form, dry_run=True)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunResizeIteration(unittest.TestCase):

--- a/tests/test_rotate_flow.py
+++ b/tests/test_rotate_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.flow_result import FlowResult
 from usecases.rotate_flow import (
@@ -61,7 +61,7 @@ class TestExecuteRotate(unittest.TestCase):
         mock_build.return_value = ["ffmpeg", "..."]
         execute_rotate(form)
         mock_build.assert_called_once_with(input_file="in.mp4", output_file="out.mp4", direction="right90")
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.rotate_flow.build_rotate_command")
@@ -69,7 +69,7 @@ class TestExecuteRotate(unittest.TestCase):
         form = RotateForm(input_file="in.mp4", direction="hflip", output_file="out.mp4")
         mock_build.return_value = ["ffmpeg", "..."]
         execute_rotate(form, dry_run=True)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunRotateIteration(unittest.TestCase):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,12 +1,14 @@
 import subprocess
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from ffmpeg.runner import RunResult, run_ffmpeg
+from ffmpeg.runner import RunResult, parse_progress_chunk, run_ffmpeg
 from shared.errors import FfmpegExecutionError
 
 
 class TestRunFfmpeg(unittest.TestCase):
+    # 仕様: callback なしの通常パスは既存の subprocess.run ベースの動作を維持する
+
     @patch("ffmpeg.runner.subprocess.run")
     def test_run_ffmpeg_executes_subprocess_when_not_dry_run(self, mock_run):
         command = ["ffmpeg", "-version"]
@@ -32,6 +34,101 @@ class TestRunFfmpeg(unittest.TestCase):
 
         with self.assertRaises(FfmpegExecutionError):
             run_ffmpeg(command)
+
+
+def _make_mock_popen(stdout_lines: list[str], returncode: int = 0):
+    mock_proc = MagicMock()
+    mock_proc.stdout = iter(line + "\n" for line in stdout_lines)
+    mock_proc.returncode = returncode
+    mock_proc.wait.return_value = None
+    mock_popen = MagicMock(return_value=mock_proc)
+    return mock_popen, mock_proc
+
+
+class TestRunFfmpegWithCallback(unittest.TestCase):
+    # 仕様: progress_callback を渡すと Popen ベースでリアルタイム進捗を受け取れる
+
+    @patch("ffmpeg.runner.subprocess.run")
+    def test_no_callback_uses_subprocess_run_without_modifying_command(self, mock_run):
+        # 仕様: callback=None のとき、コマンドを変えず subprocess.run を呼ぶ
+        #       既存の全呼び出し元への後方互換を保つため
+        command = ["ffmpeg", "-i", "in.mp4", "out.mp4"]
+        run_ffmpeg(command)
+        mock_run.assert_called_once_with(command, check=True)
+
+    @patch("ffmpeg.runner.subprocess.Popen")
+    def test_callback_inserts_progress_flag_immediately_after_ffmpeg(self, mock_popen_cls):
+        # 仕様: -progress pipe:1 はインデックス1（ffmpeg の直後）に挿入される
+        #       FFmpeg のグローバルオプションは -i より前に置く必要があるため
+        mock_popen, _ = _make_mock_popen(["progress=end"])
+        mock_popen_cls.side_effect = mock_popen
+        command = ["ffmpeg", "-i", "in.mp4", "out.mp4"]
+        run_ffmpeg(command, progress_callback=lambda _: None)
+        called_cmd = mock_popen_cls.call_args[0][0]
+        self.assertEqual(called_cmd[:3], ["ffmpeg", "-progress", "pipe:1"])
+
+    @patch("ffmpeg.runner.subprocess.Popen")
+    def test_callback_is_called_for_every_chunk_including_end(self, mock_popen_cls):
+        # 仕様: progress=continue と progress=end の各チャンクでコールバックを呼ぶ
+        #       progress=end 時にも呼ぶことで最終進捗（100%）を表示できる
+        lines = [
+            "frame=10", "speed=1.0x", "out_time=00:00:01.000000", "progress=continue",
+            "frame=20", "speed=1.0x", "out_time=00:00:02.000000", "progress=continue",
+            "frame=30", "speed=1.0x", "out_time=00:00:03.000000", "progress=end",
+        ]
+        mock_popen, _ = _make_mock_popen(lines)
+        mock_popen_cls.side_effect = mock_popen
+        cb = MagicMock()
+        run_ffmpeg(["ffmpeg", "-i", "in.mp4", "out.mp4"], progress_callback=cb)
+        self.assertEqual(cb.call_count, 3)
+
+    @patch("ffmpeg.runner.subprocess.Popen")
+    def test_callback_receives_parsed_progress_info(self, mock_popen_cls):
+        # 仕様: コールバックには parse_progress_chunk で変換した ProgressInfo が渡される
+        lines = ["frame=100", "speed=2.0x", "out_time=00:00:05.000000", "progress=end"]
+        mock_popen, _ = _make_mock_popen(lines)
+        mock_popen_cls.side_effect = mock_popen
+        cb = MagicMock()
+        run_ffmpeg(["ffmpeg", "-i", "in.mp4", "out.mp4"], progress_callback=cb)
+        self.assertEqual(cb.call_count, 1)
+        self.assertEqual(cb.call_args[0][0].frame, 100)
+
+    @patch("ffmpeg.runner.subprocess.Popen")
+    def test_nonzero_exit_raises_ffmpeg_execution_error(self, mock_popen_cls):
+        # 仕様: FFmpeg が非ゼロで終了したとき FfmpegExecutionError を送出する
+        mock_popen, _ = _make_mock_popen(["progress=end"], returncode=1)
+        mock_popen_cls.side_effect = mock_popen
+        with self.assertRaises(FfmpegExecutionError):
+            run_ffmpeg(["ffmpeg", "-i", "in.mp4", "out.mp4"], progress_callback=lambda _: None)
+
+
+class TestParseProgressChunk(unittest.TestCase):
+    # 仕様: FFmpeg の -progress pipe:1 出力（key=value 形式）を ProgressInfo に変換する
+
+    def test_out_time_is_trimmed_to_seconds_precision(self):
+        # 仕様: out_time のマイクロ秒以下（.ffffff）は切り捨て、HH:MM:SS 形式で返す
+        lines = ["out_time=00:01:30.000000", "progress=continue"]
+        info = parse_progress_chunk(lines)
+        self.assertEqual(info.out_time, "00:01:30")
+
+    def test_speed_is_preserved_as_string(self):
+        # 仕様: speed は "2.0x" のように単位込みの文字列のまま保持する
+        lines = ["speed=2.0x", "progress=continue"]
+        info = parse_progress_chunk(lines)
+        self.assertEqual(info.speed, "2.0x")
+
+    def test_frame_is_parsed_as_int(self):
+        # 仕様: frame は整数にパースする
+        lines = ["frame=120", "progress=continue"]
+        info = parse_progress_chunk(lines)
+        self.assertEqual(info.frame, 120)
+
+    def test_missing_fields_fall_back_to_defaults(self):
+        # 仕様: チャンクにフィールドがなければ frame=0, speed="", out_time="" を返す
+        info = parse_progress_chunk(["progress=continue"])
+        self.assertEqual(info.frame, 0)
+        self.assertEqual(info.speed, "")
+        self.assertEqual(info.out_time, "")
 
 
 if __name__ == "__main__":

--- a/tests/test_shared_flow.py
+++ b/tests/test_shared_flow.py
@@ -1,35 +1,75 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
-from usecases.shared_flow import execute_with_output
+from ffmpeg.runner import ProgressInfo
+from usecases.shared_flow import execute_with_output, make_cli_progress_callback
 
 
 class TestExecuteWithOutput(unittest.TestCase):
+    # 仕様: execute_with_output はコマンドを表示し、run_ffmpeg を呼び、完了メッセージを出す
+
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.shared_flow.format_command")
     def test_prints_command_and_completion_on_execute(self, mock_format, mock_run):
+        # 仕様: 実行前にコマンドを表示し、実行後に完了ファイル名を表示する
         mock_format.return_value = "ffmpeg -i input.mp4 output.mp4"
         mock_run.return_value = MagicMock(executed=True)
 
         with patch("builtins.print") as mock_print:
             execute_with_output(["ffmpeg", "-i", "input.mp4", "output.mp4"], "output.mp4", dry_run=False)
 
-        mock_run.assert_called_once_with(["ffmpeg", "-i", "input.mp4", "output.mp4"], dry_run=False)
-        printed = [str(call.args[0]) for call in mock_print.call_args_list if call.args]
+        mock_run.assert_called_once_with(
+            ["ffmpeg", "-i", "input.mp4", "output.mp4"], dry_run=False, progress_callback=ANY
+        )
+        printed = [str(c.args[0]) for c in mock_print.call_args_list if c.args]
         self.assertIn("生成された FFmpeg コマンド:", printed)
         self.assertIn("完了: output.mp4", printed)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.shared_flow.format_command")
     def test_prints_dry_run_message_when_not_executed(self, mock_format, mock_run):
+        # 仕様: dry_run=True のとき「ドライラン完了」メッセージを表示する
         mock_format.return_value = "ffmpeg -i input.mp4 output.mp4"
         mock_run.return_value = MagicMock(executed=False)
 
         with patch("builtins.print") as mock_print:
             execute_with_output(["ffmpeg", "-i", "input.mp4", "output.mp4"], "output.mp4", dry_run=True)
 
-        printed = [str(call.args[0]) for call in mock_print.call_args_list if call.args]
+        printed = [str(c.args[0]) for c in mock_print.call_args_list if c.args]
         self.assertIn("ドライラン完了: 実行はしていません。", printed)
+
+    @patch("usecases.shared_flow.run_ffmpeg")
+    def test_passes_progress_callback_to_run_ffmpeg(self, mock_run):
+        # 仕様: run_ffmpeg に callable な progress_callback を渡す
+        #       None を渡すと -progress フラグが挿入されず進捗が表示されないため
+        mock_run.return_value = MagicMock(executed=True)
+        execute_with_output(["ffmpeg", "-i", "in.mp4", "out.mp4"], "out.mp4", dry_run=False)
+        _, kwargs = mock_run.call_args
+        self.assertIsNotNone(kwargs.get("progress_callback"))
+        self.assertTrue(callable(kwargs["progress_callback"]))
+
+
+class TestMakeCliProgressCallback(unittest.TestCase):
+    # 仕様: \r で同一行を上書きし、経過時間と処理速度をリアルタイム表示するコールバックを返す
+
+    def test_writes_out_time_and_speed_with_carriage_return(self):
+        # 仕様: 経過時間（out_time）と速度（speed）を \r 付きで stdout に書き込む
+        cb = make_cli_progress_callback()
+        info = ProgressInfo(out_time="00:01:30", speed="2.0x", frame=100)
+        with patch("sys.stdout") as mock_stdout:
+            cb(info)
+        written = mock_stdout.write.call_args[0][0]
+        self.assertIn("\r", written)
+        self.assertIn("00:01:30", written)
+        self.assertIn("2.0x", written)
+
+    def test_flushes_stdout_after_write(self):
+        # 仕様: write 後に flush する（バッファリングで表示が遅延しないため）
+        cb = make_cli_progress_callback()
+        info = ProgressInfo(out_time="00:00:05", speed="1.5x", frame=10)
+        with patch("sys.stdout") as mock_stdout:
+            cb(info)
+        mock_stdout.flush.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_speed_flow.py
+++ b/tests/test_speed_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.flow_result import FlowResult
 from usecases.speed_flow import (
@@ -64,7 +64,7 @@ class TestExecuteSpeed(unittest.TestCase):
         mock_build.return_value = ["ffmpeg", "..."]
         execute_speed(form)
         mock_build.assert_called_once_with(input_file="in.mp4", output_file="out.mp4", speed=2.0)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.speed_flow.build_speed_command")
@@ -72,7 +72,7 @@ class TestExecuteSpeed(unittest.TestCase):
         form = SpeedForm(input_file="in.mp4", speed_raw="2.0", output_file="out.mp4")
         mock_build.return_value = ["ffmpeg", "..."]
         execute_speed(form, dry_run=True)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunSpeedIteration(unittest.TestCase):

--- a/tests/test_thumbnail_flow.py
+++ b/tests/test_thumbnail_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.flow_result import FlowResult
 from usecases.thumbnail_flow import (
@@ -64,7 +64,7 @@ class TestExecuteThumbnail(unittest.TestCase):
         mock_build.return_value = ["ffmpeg", "..."]
         execute_thumbnail(form)
         mock_build.assert_called_once_with(input_file="in.mp4", output_file="out.jpg", timestamp_seconds=10)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.thumbnail_flow.build_thumbnail_command")
@@ -72,7 +72,7 @@ class TestExecuteThumbnail(unittest.TestCase):
         form = ThumbnailForm(input_file="in.mp4", timestamp_raw="10", output_file="out.jpg")
         mock_build.return_value = ["ffmpeg", "..."]
         execute_thumbnail(form, dry_run=True)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunThumbnailIteration(unittest.TestCase):

--- a/tests/test_trim_flow.py
+++ b/tests/test_trim_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.flow_result import FlowResult
 from usecases.trim_flow import (
@@ -68,7 +68,7 @@ class TestExecuteTrim(unittest.TestCase):
         self.assertEqual(args["output_file"], "out.mp4")
         self.assertEqual(args["trim_range"].start_seconds, 10)
         self.assertEqual(args["trim_range"].end_seconds, 20)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.trim_flow.build_trim_command")
@@ -76,7 +76,7 @@ class TestExecuteTrim(unittest.TestCase):
         form = TrimForm(input_file="in.mp4", start_raw="10", end_raw="20", output_file="out.mp4")
         mock_build_command.return_value = ["ffmpeg", "..."]
         execute_trim(form, dry_run=True)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunTrimIteration(unittest.TestCase):

--- a/tests/test_volume_flow.py
+++ b/tests/test_volume_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from usecases.flow_result import FlowResult
 from usecases.volume_flow import (
@@ -64,7 +64,7 @@ class TestExecuteVolume(unittest.TestCase):
         mock_build_volume_command.return_value = ["ffmpeg", "..."]
         execute_volume(form)
         mock_build_volume_command.assert_called_once_with(input_file="in.mp4", output_file="out.mp4", volume_level=1.5)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=False, progress_callback=ANY)
 
     @patch("usecases.shared_flow.run_ffmpeg")
     @patch("usecases.volume_flow.build_volume_command")
@@ -72,7 +72,7 @@ class TestExecuteVolume(unittest.TestCase):
         form = VolumeForm(input_file="in.mp4", volume_raw="1.5", output_file="out.mp4")
         mock_build_volume_command.return_value = ["ffmpeg", "..."]
         execute_volume(form, dry_run=True)
-        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True)
+        mock_run_ffmpeg.assert_called_once_with(["ffmpeg", "..."], dry_run=True, progress_callback=ANY)
 
 
 class TestRunVolumeIteration(unittest.TestCase):

--- a/usecases/shared_flow.py
+++ b/usecases/shared_flow.py
@@ -1,6 +1,8 @@
-from typing import Any, Callable
+import sys
+from collections.abc import Callable
+from typing import Any
 
-from ffmpeg.runner import run_ffmpeg
+from ffmpeg.runner import ProgressInfo, run_ffmpeg
 from shared.command_formatter import format_command
 from shared.errors import ValidationError
 from usecases.flow_result import FLOW_RESULT_FACTORIES, FlowResult
@@ -18,14 +20,26 @@ _REVIEW_CHOICES = [
 ]
 
 
+def make_cli_progress_callback() -> Callable[[ProgressInfo], None]:
+    # print ではなく sys.stdout.write + flush を使う。
+    # print は改行を付加するため \r による行上書きができないため。
+    def callback(info: ProgressInfo) -> None:
+        sys.stdout.write(f"\r経過時間: {info.out_time}  速度: {info.speed}    ")
+        sys.stdout.flush()
+
+    return callback
+
+
 def execute_with_output(command: list[str], output_file: str, dry_run: bool) -> None:
     print("生成された FFmpeg コマンド:")
     print(format_command(command))
     print()
 
-    result = run_ffmpeg(command, dry_run=dry_run)
+    result = run_ffmpeg(command, dry_run=dry_run, progress_callback=make_cli_progress_callback())
 
     if result.executed:
+        # プログレスバーの \r 行の後に改行してから完了メッセージを出す
+        print()
         print(f"完了: {output_file}")
     else:
         print("ドライラン完了: 実行はしていません。")


### PR DESCRIPTION
closes #47

## 変更内容

### `ffmpeg/runner.py`
- `ProgressInfo` dataclass 追加（`frame`, `speed`, `out_time`）
- `parse_progress_chunk()` 追加 — `-progress pipe:1` 出力（key=value）を `ProgressInfo` に変換
- `run_ffmpeg()` に `progress_callback` 引数を追加
  - `callback=None` のとき従来の `subprocess.run` を使う（後方互換維持）
  - `callback` 指定時は `Popen` に切り替え、`progress=continue/end` チャンクごとにコールバックを呼ぶ
  - `-progress pipe:1` を ffmpeg 直後（index 1）に挿入
  - stderr はキャプチャして非ゼロ終了時の `FfmpegExecutionError.detail` に含める

### `usecases/shared_flow.py`
- `make_cli_progress_callback()` 追加 — `\r` で同一行を上書きし経過時間・速度を表示
- `execute_with_output()` を更新して CLI コールバックを `run_ffmpeg` に渡す

## 設計上の判断

- `out_time_ms` ではなく `out_time`（文字列）を使用: FFmpeg の `out_time_ms` はフィールド名に反してマイクロ秒単位であり混乱を招くため
- `stderr=subprocess.PIPE`: `DEVNULL` だとエラー原因が隠れるため、失敗時の detail に含める
- `-progress pipe:1` は index 1 に挿入: FFmpeg のグローバルオプションは `-i` より前に置く必要があるため

## 動作確認

```
生成された FFmpeg コマンド:
ffmpeg -y -i /tmp/test_input.mp4 -c:v libx264 -crf 28 -c:a aac /tmp/test_output.mp4

経過時間: 00:00:09  速度: 32.9x
完了: /tmp/test_output.mp4
```

## テスト
- `test_runner.py`: 12 件（parse / callback 挿入 / チャンク呼び出し / エラー）
- `test_shared_flow.py`: 5 件（プログレス表示 / flush / callback 受け渡し）
- 既存 14 フローのテストも `progress_callback=ANY` で更新済み
- 全 378 件 Green